### PR TITLE
[Scripts/ImportNTDS.ps1] copy certificate instead of moving

### DIFF
--- a/dist/Scripts/ImportNTDS.ps1
+++ b/dist/Scripts/ImportNTDS.ps1
@@ -56,12 +56,12 @@ if ($CertInStore)
     try
 	{
         if ( ( Test-Path $destination ) -and $CertInStore ) {
-            Move-Item "HKLM:\SOFTWARE\Microsoft\SystemCertificates\MY\Certificates\$NewCertThumbprint" $destination
+            Copy-Item "HKLM:\SOFTWARE\Microsoft\SystemCertificates\MY\Certificates\$NewCertThumbprint" $destination
         }
     }
 	catch 
 	{
-        "Could not move certificate into NDTS store location."
+        "Could not copy certificate into NDTS store location."
         "Error: $($Error[0])"
 		return
     }


### PR DESCRIPTION
This allows the certificate to be used for other purposes such as RDS or AD FS.

I found this issue on our DC which already had valid certificates for RDS. After adding the NT DS deployment the certificate was (re)moved from the computer store and the RDS connection showed a certificate warning again.

The description already says to copy the cert:
> The script will copy this cert to the Personal store if not already there.
