### PR TITLE
Add HuaWeiCloud Dns validation

### DIFF
--- a/src/plugin.validation.dns.huaweicloud/HuaWeiCloud.cs
+++ b/src/plugin.validation.dns.huaweicloud/HuaWeiCloud.cs
@@ -1,0 +1,209 @@
+﻿using HuaweiCloud.SDK.Core;
+using HuaweiCloud.SDK.Core.Auth;
+using HuaweiCloud.SDK.Dns.V2;
+using PKISharp.WACS.Clients.DNS;
+using PKISharp.WACS.Plugins.Base.Capabilities;
+using PKISharp.WACS.Plugins.Interfaces;
+using PKISharp.WACS.Services;
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+//Api Key: https://console.huaweicloud.com/iam/#/mine/accessKey
+//Api Doc: https://console.huaweicloud.com/apiexplorer/#/openapi/DNS/debug
+//DNS Region: https://console.huaweicloud.com/apiexplorer/#/endpoint/DNS
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
+{
+    [IPlugin.Plugin1<HuaWeiCloudOptions, HuaWeiCloudOptionsFactory, DnsValidationCapability, HuaWeiCloudJson, HuaWeiCloudArguments>
+        ("ec5a5198-7224-447e-aac5-99c2ccda78a1",
+        "HuaWeiCloud", "Create verification records in HuaWeiCloud DNS",
+        External = true, Provider = "HuaWeiCloud", Page = "huaweicloud")]
+    public class HuaWeiCloud : DnsValidation<HuaWeiCloud>, IDisposable
+    {
+        private SecretServiceManager Ssm { get; }
+        private HttpClient Hc { get; }
+        private HuaWeiCloudOptions Options { get; }
+        private HuaweiCloud.SDK.Dns.V2.DnsClient Client { get; }
+
+        public HuaWeiCloud(HuaWeiCloudOptions options, SecretServiceManager ssm,
+            IProxyService proxyService, LookupClientProvider dnsClient, ILogService log,
+            ISettingsService settings) : base(dnsClient, log, settings)
+        {
+            Options = options;
+            Ssm = ssm;
+            Hc = proxyService.GetHttpClient();
+            //GetValue
+            var dnsRegion = Ssm.EvaluateSecret(Options.DnsRegion);
+            var keyID = Ssm.EvaluateSecret(Options.KeyID);
+            var keySecret = Ssm.EvaluateSecret(Options.KeySecret);
+            try
+            {
+                var auth = new BasicCredentials(Ssm.EvaluateSecret(keyID), Ssm.EvaluateSecret(keySecret));
+                var config = HttpConfig.GetDefaultConfig();
+                config.IgnoreSslVerification = true;
+                //New Client
+                Client = HuaweiCloud.SDK.Dns.V2.DnsClient.NewBuilder()
+                        .WithCredential(auth)
+                        .WithRegion(DnsRegion.ValueOf(dnsRegion))
+                        .WithHttpConfig(config)
+                        .Build();
+            }
+            catch (Exception ex)
+            {
+                _log.Error($"Configuration error: {ex.Message}");
+                throw new Exception("Configuration error");
+            }
+        }
+
+        public override async Task<bool> CreateRecord(DnsValidationRecord record)
+        {
+            try
+            {
+                var identifier = GetDomain(record) ?? throw new($"The domain name cannot be found: {record.Context.Identifier}");
+                var domain = record.Authority.Domain;
+                var value = record.Value;
+                //Add Record
+                return await AddRecord(identifier, domain, value);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+                //Out Error
+                _log.Error($"Unable to add HuaWeiCloudDNS record: {ex.Message}");
+            }
+            return false;
+        }
+
+        public override async Task DeleteRecord(DnsValidationRecord record)
+        {
+            try
+            {
+                var identifier = GetDomain(record) ?? throw new($"The domain name cannot be found: {record.Context.Identifier}");
+                var domain = record.Authority.Domain;
+                //Delete Record
+                await DelRecord(identifier, domain);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+                //Out Error
+                _log.Error($"Unable to delete HuaWeiCloudDNS record: {ex.Message}");
+            }
+        }
+
+        public void Dispose()
+        {
+            Hc.Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        #region PrivateLogic
+
+        /// <summary>
+        /// Add Record
+        /// </summary>
+        /// <param name="domain">Domain</param>
+        /// <param name="subDomain">SubDomain</param>
+        /// <param name="value">Value</param>
+        /// <returns></returns>
+        private async Task<bool> AddRecord(string domain, string subDomain, string value)
+        {
+            //Delete Record
+            var delRecord = await DelRecord(domain, subDomain);
+            //Add Record
+            Client.CreateRecordSetWithLine(new()
+            {
+                ZoneId = delRecord.Item1,
+                Body = new()
+                {
+                    Records = new()
+                    {
+                        $"\"{value}\""
+                    },
+                    Type = "TXT",
+                    Name = subDomain,
+                }
+            });
+            return true;
+        }
+
+        /// <summary>
+        /// Delete Record
+        /// </summary>
+        /// <param name="domain">Domain</param>
+        /// <param name="subDomain">SubDomain</param>
+        /// <returns></returns>
+        private async Task<(string?, bool)> DelRecord(string domain, string subDomain)
+        {
+            //Get RecordID
+            var recordId = GetRecordID(domain, subDomain);
+            while (recordId.Item2 != default)
+            {
+                //Delete Record
+                Client.DeleteRecordSets(new()
+                {
+                    ZoneId = recordId.Item1,
+                    RecordsetId = recordId.Item2
+                });
+                //Get RecordID
+                await Task.Delay(300);
+                recordId = GetRecordID(domain, subDomain);
+            }
+            return (recordId.Item1, true);
+        }
+
+        /// <summary>
+        /// Get RecordID
+        /// </summary>
+        /// <param name="domain">Domain</param>
+        /// <param name="subDomain">SubDomain</param>
+        /// <returns></returns>
+        private (string?, string?) GetRecordID(string domain, string? subDomain = default)
+        {
+            //domain
+            var resp1 = Client.ListRecordSetsWithLine(new()
+            {
+                Type = "NS",
+                Name = domain.TrimEnd('.'),
+            });
+            if (resp1.Recordsets.Count == 0) throw new($"Domain: {domain}, Does not exist");
+            var zoneId = resp1.Recordsets.First().ZoneId;
+            //subDomain
+            if (subDomain != default)
+            {
+                var resp2 = Client.ListRecordSetsWithLine(new()
+                {
+                    Type = "TXT",
+                    Name = subDomain,
+                });
+                if (resp2.Recordsets.Count != 0)
+                {
+                    var recordID = resp2.Recordsets.First().Id;
+                    return (zoneId, recordID);
+                }
+            }
+            return (zoneId, default);
+        }
+
+        /// <summary>
+        /// Get Domain
+        /// </summary>
+        /// <param name="record">DnsValidationRecord</param>
+        /// <returns></returns>
+        private string? GetDomain(DnsValidationRecord record)
+        {
+            var resp = Client.ListRecordSetsWithLine(new()
+            {
+                Type = "NS"
+            });
+            //Console.WriteLine(resp.Recordsets);
+            var myDomains = resp.Recordsets.Select(t => t.Name);
+            var zone = FindBestMatch(myDomains.ToDictionary(x => x), record.Authority.Domain);
+            if (zone != null) return zone;
+            return default;
+        }
+
+        #endregion PrivateLogic
+    }
+}

--- a/src/plugin.validation.dns.huaweicloud/HuaWeiCloudArguments.cs
+++ b/src/plugin.validation.dns.huaweicloud/HuaWeiCloudArguments.cs
@@ -1,0 +1,17 @@
+﻿using PKISharp.WACS.Configuration;
+using PKISharp.WACS.Configuration.Arguments;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
+{
+    public class HuaWeiCloudArguments : BaseArguments
+    {
+        [CommandLine(Description = "DNS Region. Refer: https://console.huaweicloud.com/apiexplorer/#/endpoint/DNS", Secret = false)]
+        public string? HuaWeiCloudDnsRegion { get; set; } = "cn-south-1";
+
+        [CommandLine(Description = "Access KeyId for HuaWeiCloud.", Secret = true)]
+        public string? HuaWeiCloudKeyID { get; set; }
+
+        [CommandLine(Description = "Access KeySecret for HuaWeiCloud.", Secret = true)]
+        public string? HuaWeiCloudKeySecret { get; set; }
+    }
+}

--- a/src/plugin.validation.dns.huaweicloud/HuaWeiCloudOptions.cs
+++ b/src/plugin.validation.dns.huaweicloud/HuaWeiCloudOptions.cs
@@ -1,0 +1,32 @@
+﻿using PKISharp.WACS.Plugins.Base.Options;
+using PKISharp.WACS.Services.Serialization;
+using System.Text.Json.Serialization;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
+{
+    [JsonSerializable(typeof(HuaWeiCloudOptions))]
+    internal partial class HuaWeiCloudJson : JsonSerializerContext
+    {
+        public HuaWeiCloudJson(WacsJsonPluginsOptionsFactory optionsFactory) : base(optionsFactory.Options)
+        {
+        }
+    }
+
+    public class HuaWeiCloudOptions : ValidationPluginOptions
+    {
+        /// <summary>
+        /// DnsRegion
+        /// </summary>
+        public string? DnsRegion { get; set; }
+
+        /// <summary>
+        /// KeyID
+        /// </summary>
+        public ProtectedString? KeyID { get; set; }
+
+        /// <summary>
+        /// KeySecret
+        /// </summary>
+        public ProtectedString? KeySecret { get; set; }
+    }
+}

--- a/src/plugin.validation.dns.huaweicloud/HuaWeiCloudOptionsFactory.cs
+++ b/src/plugin.validation.dns.huaweicloud/HuaWeiCloudOptionsFactory.cs
@@ -1,0 +1,45 @@
+﻿using PKISharp.WACS.Configuration;
+using PKISharp.WACS.Plugins.Base.Factories;
+using PKISharp.WACS.Services;
+using PKISharp.WACS.Services.Serialization;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
+{
+    public class HuaWeiCloudOptionsFactory(ArgumentsInputService arguments) : PluginOptionsFactory<HuaWeiCloudOptions>
+    {
+        private ArgumentResult<string?> DnsRegion => arguments.GetString<HuaWeiCloudArguments>(a => a.HuaWeiCloudDnsRegion).Required();
+
+        private ArgumentResult<ProtectedString?> KeyID => arguments.GetProtectedString<HuaWeiCloudArguments>(a => a.HuaWeiCloudKeyID).Required();
+
+        private ArgumentResult<ProtectedString?> KeySecret => arguments.GetProtectedString<HuaWeiCloudArguments>(a => a.HuaWeiCloudKeySecret).Required();
+
+        public override async Task<HuaWeiCloudOptions?> Aquire(IInputService inputService, RunLevel runLevel)
+        {
+            return new HuaWeiCloudOptions
+            {
+                DnsRegion = await DnsRegion.Interactive(inputService, "HuaWeiCloud Dns Region").GetValue(),
+                KeyID = await KeyID.Interactive(inputService, "HuaWeiCloud AccessKey ID").GetValue(),
+                KeySecret = await KeySecret.Interactive(inputService, "HuaWeiCloud AccessKey Secret").GetValue(),
+            };
+        }
+
+        public override async Task<HuaWeiCloudOptions?> Default()
+        {
+            return new HuaWeiCloudOptions
+            {
+                DnsRegion = await DnsRegion.GetValue(),
+                KeyID = await KeyID.GetValue(),
+                KeySecret = await KeySecret.GetValue(),
+            };
+        }
+
+        public override IEnumerable<(CommandLineAttribute, object?)> Describe(HuaWeiCloudOptions options)
+        {
+            yield return (DnsRegion.Meta, options.DnsRegion);
+            yield return (KeyID.Meta, options.KeyID);
+            yield return (KeySecret.Meta, options.KeySecret);
+        }
+    }
+}

--- a/src/plugin.validation.dns.huaweicloud/wacs.validation.dns.huaweicloud.csproj
+++ b/src/plugin.validation.dns.huaweicloud/wacs.validation.dns.huaweicloud.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>PKISharp.WACS.Plugins.ValidationPlugins</RootNamespace>
+    <AssemblyName>PKISharp.WACS.Plugins.ValidationPlugins.HuaWeiCloud</AssemblyName>
+    <Version>2.1.0.0</Version>
+    <AssemblyVersion>2.1.0.0</AssemblyVersion>
+    <FileVersion>2.1.0.0</FileVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="HuaweiCloud.SDK.Dns" Version="3.1.121" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\main.lib\wacs.lib.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/wacs.sln
+++ b/src/wacs.sln
@@ -75,6 +75,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "wacs.validation.dns.dnsexit
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "wacs.validation.dns.hetzner", "plugin.validation.dns.hetzner\wacs.validation.dns.hetzner.csproj", "{DB1444F5-3771-4825-8228-5E1651E84998}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "wacs.validation.dns.huaweicloud", "plugin.validation.dns.huaweicloud\wacs.validation.dns.huaweicloud.csproj", "{EC5A5198-7224-447E-AAC5-99C2CCDA78A1}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "wacs.validation.http.ftp", "plugin.validation.http.ftp\wacs.validation.http.ftp.csproj", "{D0AE9B01-9D7B-4325-9466-7F0BB109FA5D}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "wacs.validation.http.sftp", "plugin.validation.http.sftp\wacs.validation.http.sftp.csproj", "{E4ACC01A-E30E-4037-B282-7DB5B94366D6}"
@@ -293,6 +295,14 @@ Global
 		{DB1444F5-3771-4825-8228-5E1651E84998}.Release|Any CPU.Build.0 = Release|Any CPU
 		{DB1444F5-3771-4825-8228-5E1651E84998}.ReleaseTrimmed|Any CPU.ActiveCfg = Debug|Any CPU
 		{DB1444F5-3771-4825-8228-5E1651E84998}.ReleaseTrimmed|Any CPU.Build.0 = Debug|Any CPU
+		{EC5A5198-7224-447E-AAC5-99C2CCDA78A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC5A5198-7224-447E-AAC5-99C2CCDA78A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC5A5198-7224-447E-AAC5-99C2CCDA78A1}.DebugTrimmed|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC5A5198-7224-447E-AAC5-99C2CCDA78A1}.DebugTrimmed|Any CPU.Build.0 = Debug|Any CPU
+		{EC5A5198-7224-447E-AAC5-99C2CCDA78A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC5A5198-7224-447E-AAC5-99C2CCDA78A1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC5A5198-7224-447E-AAC5-99C2CCDA78A1}.ReleaseTrimmed|Any CPU.ActiveCfg = Release|Any CPU
+		{EC5A5198-7224-447E-AAC5-99C2CCDA78A1}.ReleaseTrimmed|Any CPU.Build.0 = Release|Any CPU
 		{D0AE9B01-9D7B-4325-9466-7F0BB109FA5D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D0AE9B01-9D7B-4325-9466-7F0BB109FA5D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D0AE9B01-9D7B-4325-9466-7F0BB109FA5D}.DebugTrimmed|Any CPU.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
Add HuaWeiCloud Dns validation

- Api Key: https://console.huaweicloud.com/iam/#/mine/accessKey
- Api Doc: https://console.huaweicloud.com/apiexplorer/#/openapi/DNS/debug
- DNS Region: https://console.huaweicloud.com/apiexplorer/#/endpoint/DNS

<hr />

@WouterTinus I didn't find any information about the dll list configuration (previously create-artifacts.ps1)
> The dll required for this extension is as follows:
```
PKISharp.WACS.Plugins.ValidationPlugins.HuaWeiCloud.dll
BouncyCastle.Cryptography.dll
HuaweiCloud.SDK.Core.dll
HuaweiCloud.SDK.Dns.dll
Microsoft.Extensions.Http.Polly.dll
Newtonsoft.Json.dll
Polly.dll
Polly.Extensions.Http.dll
YamlDotNet.dll
```