### PR TITLE
Add --challengeroot as alternative to --webroot 

### DIFF
--- a/src/main.lib/Configuration/NetworkCredentialOptions.cs
+++ b/src/main.lib/Configuration/NetworkCredentialOptions.cs
@@ -11,7 +11,9 @@ namespace PKISharp.WACS.Configuration
 {
     public interface INetworkCredentialArguments : IArguments
     {
+        [CommandLine(Description = "Username for remote server")]
         public string? UserName { get; }
+        [CommandLine(Description = "Password for remote server", Secret = true)]
         public string? Password { get; }
     }
 

--- a/src/main.lib/Plugins/ValidationPlugins/Http/HttpValidationArguments.cs
+++ b/src/main.lib/Plugins/ValidationPlugins/Http/HttpValidationArguments.cs
@@ -5,8 +5,14 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Http
 {
     public abstract class HttpValidationArguments : BaseArguments
     {
-        [CommandLine(Description = "Root path of the site that will serve the HTTP validation requests.")]
+        [CommandLine(Obsolete = true)]
+        public string? Root { get; set; }
+
+        [CommandLine(Description = "Root path of the website. Note that /.well-known/acme-challenge/ will be appended automatically. Use --challengeroot instead if you do not want this to happen, e.g. to use a credential with limited access.")]
         public string? WebRoot { get; set; }
+
+        [CommandLine(Description = "Root path for the /.well-known/acme-challenge/ folder for this domain.")]
+        public string? ChallengeRoot { get; set; }
 
         [CommandLine(Obsolete = true, Description = "Not used (warmup is the new default).")]
         public bool Warmup { get; set; }

--- a/src/main.lib/Plugins/ValidationPlugins/Http/HttpValidationOptions.cs
+++ b/src/main.lib/Plugins/ValidationPlugins/Http/HttpValidationOptions.cs
@@ -7,12 +7,14 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Http
     {
         public string? Path { get; set; }
         public bool? CopyWebConfig { get; set; }
+        public bool? IsRootPath { get; set; }
 
         public HttpValidationOptions() { }
         public HttpValidationOptions(HttpValidationOptions? source)
         {
             Path = source?.Path;
             CopyWebConfig = source?.CopyWebConfig;
+            IsRootPath = source?.IsRootPath;
         }
 
         public override void Show(IInputService input)
@@ -26,6 +28,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Http
             {
                 input.Show("Web.config", "Yes", level: 1);
             }
+            input.Show("Root path", IsRootPath == false ? "No" : "Yes", level: 1);
         }
     }
 }

--- a/src/main.lib/Plugins/ValidationPlugins/Http/SelfHosting/SelfHosting.cs
+++ b/src/main.lib/Plugins/ValidationPlugins/Http/SelfHosting/SelfHosting.cs
@@ -69,7 +69,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Http
         public override async Task<bool> PrepareChallenge(ValidationContext context, Http01ChallengeValidationDetails challenge)
         {
             // Add validation file
-            _files.GetOrAdd("/" + challenge.HttpResourcePath, challenge.HttpResourceValue);
+            _files.GetOrAdd($"/{Http01ChallengeValidationDetails.HttpPathPrefix}/{challenge.HttpResourceName}", challenge.HttpResourceValue);
             await TestChallenge(challenge);
             return true;
         }

--- a/src/main.lib/Services/ArgumentResult.cs
+++ b/src/main.lib/Services/ArgumentResult.cs
@@ -196,8 +196,8 @@ namespace PKISharp.WACS.Services
         }
 
         /// <summary>
-        /// Set a default value if not value was
-        /// specified so far
+        /// Return null if the user has provided a value 
+        /// that matches the default value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>

--- a/src/main.lib/Services/ArgumentsInputService.cs
+++ b/src/main.lib/Services/ArgumentsInputService.cs
@@ -103,10 +103,14 @@ namespace PKISharp.WACS.Services
             {
                 throw new InvalidOperationException($"Missing argumentprovider for type {typeof(T).Name}");
             }
-            var argumentName = GetMetaData(action).ArgumentName;
+            var meta = GetMetaData(action);
+            var argumentName = meta.ArgumentName;
             if (returnValue == null)
             {
-                log.Verbose("No value provided for {optionName}", $"--{argumentName}");
+                if (!meta.Obsolete)
+                {
+                    log.Verbose("No value provided for {optionName}", $"--{argumentName}");
+                }
             }
             else
             {


### PR DESCRIPTION
Can be used to "deeplink" file uploads (FTP/SFTP/WebDav/FS) to the "/.well-known/acme-challenge/" folder, making it a lot easier to use limited credentials or virtual directories.