### PR TITLE
Associate friendlyname with first certificate in the chain

### DIFF
--- a/src/main.lib/Services/CertificateService.cs
+++ b/src/main.lib/Services/CertificateService.cs
@@ -236,7 +236,7 @@ namespace PKISharp.WACS.Services
                     var bcCertAlias = bcCertificateEntry.Certificate.SubjectDN.CommonName(true);
                     log.Verbose("Certificate {name} parsed", bcCertAlias);
 
-                    var bcCertificateAlias = startIndex == 0 ?
+                    var bcCertificateAlias = pfx.Count == 0 ?
                         friendlyName :
                         bcCertAlias;
                     pfx.SetCertificateEntry(bcCertificateAlias, bcCertificateEntry);


### PR DESCRIPTION
...which might not be at index == 0
closes: https://github.com/simple-acme/simple-acme/issues/134

