### PR TITLE
Fix path separator on Linux

### DIFF
--- a/src/main.lib/Plugins/ValidationPlugins/Http/HttpValidation.cs
+++ b/src/main.lib/Plugins/ValidationPlugins/Http/HttpValidation.cs
@@ -64,7 +64,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Http
         /// but overridden to be a hardcoded / for (S)FTP and WebDav 
         /// protocols
         /// </summary>
-        protected virtual char PathSeparator => Path.PathSeparator;
+        protected virtual char PathSeparator => Path.DirectorySeparatorChar;
 
         /// <summary>
         /// Handle http challenge

--- a/src/main.lib/Plugins/ValidationPlugins/Http/HttpValidation.cs
+++ b/src/main.lib/Plugins/ValidationPlugins/Http/HttpValidation.cs
@@ -60,9 +60,11 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Http
         protected static string TemplateWebConfig => Path.Combine(VersionService.ResourcePath, "web_config.xml");
 
         /// <summary>
-        /// Character to separate folders, different for FTP 
+        /// Character to separate folders, OS specific in the general case
+        /// but overridden to be a hardcoded / for (S)FTP and WebDav 
+        /// protocols
         /// </summary>
-        protected virtual char PathSeparator => '\\';
+        protected virtual char PathSeparator => Path.PathSeparator;
 
         /// <summary>
         /// Handle http challenge


### PR DESCRIPTION
Bug -

The file system plugin on Linux was still using Windows-style path separators (`\` instead of `/`). Reported by @iceburgy in https://github.com/simple-acme/simple-acme/issues/158.