### PR TITLE
Split plugin enable state between execution and configuration

### DIFF
--- a/src/main.lib/Clients/Acme/OrderManager.cs
+++ b/src/main.lib/Clients/Acme/OrderManager.cs
@@ -228,7 +228,7 @@ namespace PKISharp.WACS.Clients.Acme
             if (existingOrder.Payload.Status != AcmeClient.OrderValid &&
                 existingOrder.Payload.Status != AcmeClient.OrderReady)
             {
-                log.Warning("Cached order has status {status}, discarding", existingOrder.Payload.Status);
+                log.Debug("Cached order has status {status}, discarding", existingOrder.Payload.Status);
                 DeleteFromCache(cacheKey);
                 return null;
             }

--- a/src/main.lib/OrderProcessor.cs
+++ b/src/main.lib/OrderProcessor.cs
@@ -354,7 +354,7 @@ namespace PKISharp.WACS
                 var state = csrPlugin.Capability.ExecutionState;
                 if (state.Disabled)
                 {
-                    context.OrderResult.AddErrorMessage($"CSR plugin is not available. {state.Disabled}");
+                    context.OrderResult.AddErrorMessage($"CSR plugin is not available. Reason: {state.Reason}");
                     return null;
                 }
             }

--- a/src/main.lib/OrderProcessor.cs
+++ b/src/main.lib/OrderProcessor.cs
@@ -351,7 +351,7 @@ namespace PKISharp.WACS
             var csrPlugin = context.Target.UserCsrBytes == null ? context.OrderScope.Resolve<PluginBackend<ICsrPlugin, IPluginCapability, CsrPluginOptions>>() : null;
             if (csrPlugin != null)
             {
-                var state = csrPlugin.Capability.State;
+                var state = csrPlugin.Capability.ExecutionState;
                 if (state.Disabled)
                 {
                     context.OrderResult.AddErrorMessage($"CSR plugin is not available. {state.Disabled}");
@@ -398,7 +398,7 @@ namespace PKISharp.WACS
                     {
                         log.Information("Store with {name}...", store.Meta.Name);
                     }
-                    var state = store.Capability.State;
+                    var state = store.Capability.ExecutionState;
                     if (state.Disabled)
                     {
                         context.OrderResult.AddErrorMessage($"Store plugin is not available. {state.Reason}");
@@ -489,7 +489,7 @@ namespace PKISharp.WACS
                     {
                         log.Information("Installing with {name}...", installationPlugin.Meta.Name);
                     }
-                    var state = installationPlugin.Capability.State;
+                    var state = installationPlugin.Capability.ExecutionState;
                     if (state.Disabled)
                     {
                         context.OrderResult.AddErrorMessage($"Installation plugin is not available. {state.Reason}");

--- a/src/main.lib/Plugins/Base/Capabilities/DefaultCapability.cs
+++ b/src/main.lib/Plugins/Base/Capabilities/DefaultCapability.cs
@@ -5,5 +5,7 @@ namespace PKISharp.WACS.Plugins.Base.Capabilities
     public class DefaultCapability : IPluginCapability
     {
         public virtual State ExecutionState => State.EnabledState();
+
+        public virtual State ConfigurationState => ExecutionState;
     }
 }

--- a/src/main.lib/Plugins/Base/Capabilities/DefaultCapability.cs
+++ b/src/main.lib/Plugins/Base/Capabilities/DefaultCapability.cs
@@ -4,6 +4,6 @@ namespace PKISharp.WACS.Plugins.Base.Capabilities
 {
     public class DefaultCapability : IPluginCapability
     {
-        public virtual State State => State.EnabledState();
+        public virtual State ExecutionState => State.EnabledState();
     }
 }

--- a/src/main.lib/Plugins/Base/Capabilities/ValidationCapability.cs
+++ b/src/main.lib/Plugins/Base/Capabilities/ValidationCapability.cs
@@ -15,7 +15,8 @@ namespace PKISharp.WACS.Plugins.Base.Capabilities
     {
         protected readonly Target Target = target;
         public override IEnumerable<string> ChallengeTypes => [Constants.Http01ChallengeType];
-        public override State ExecutionState => 
+        public override State ExecutionState => ConfigurationState;
+        public override State ConfigurationState => 
             Target.GetIdentifiers(false).Any(x => x.Value.StartsWith("*.")) ? 
             State.DisabledState("HTTP validation cannot be used for wildcard identifiers (e.g. *.example.com)") : 
             State.EnabledState();
@@ -25,7 +26,8 @@ namespace PKISharp.WACS.Plugins.Base.Capabilities
     {
         protected readonly Target Target = target;
         public override IEnumerable<string> ChallengeTypes => [Constants.Dns01ChallengeType];
-        public override State ExecutionState =>
+        public override State ExecutionState => ConfigurationState;
+        public override State ConfigurationState =>
             !Target.Parts.SelectMany(x => x.Identifiers).All(x => x.Type == IdentifierType.DnsName) ?
             State.DisabledState("DNS validation can only be used for DNS identifiers") :
             State.EnabledState();
@@ -35,7 +37,8 @@ namespace PKISharp.WACS.Plugins.Base.Capabilities
     {
         protected readonly Target Target = target;
         public override IEnumerable<string> ChallengeTypes => [Constants.TlsAlpn01ChallengeType];
-        public override State ExecutionState =>
+        public override State ExecutionState => ConfigurationState;
+        public override State ConfigurationState =>
             Target.GetIdentifiers(false).Any(x => x.Value.StartsWith("*.")) ?
             State.DisabledState("TLS-ALPN validation cannot be used for wildcard identifiers (e.g. *.example.com)") :
             State.EnabledState();
@@ -46,5 +49,6 @@ namespace PKISharp.WACS.Plugins.Base.Capabilities
         protected readonly Target Target = target;
         public override IEnumerable<string> ChallengeTypes => [Constants.Dns01ChallengeType, Constants.Http01ChallengeType, Constants.TlsAlpn01ChallengeType];
         public override State ExecutionState => State.EnabledState();
+        public override State ConfigurationState => State.EnabledState();
     }
 }

--- a/src/main.lib/Plugins/Base/Capabilities/ValidationCapability.cs
+++ b/src/main.lib/Plugins/Base/Capabilities/ValidationCapability.cs
@@ -15,7 +15,7 @@ namespace PKISharp.WACS.Plugins.Base.Capabilities
     {
         protected readonly Target Target = target;
         public override IEnumerable<string> ChallengeTypes => [Constants.Http01ChallengeType];
-        public override State State => 
+        public override State ExecutionState => 
             Target.GetIdentifiers(false).Any(x => x.Value.StartsWith("*.")) ? 
             State.DisabledState("HTTP validation cannot be used for wildcard identifiers (e.g. *.example.com)") : 
             State.EnabledState();
@@ -25,7 +25,7 @@ namespace PKISharp.WACS.Plugins.Base.Capabilities
     {
         protected readonly Target Target = target;
         public override IEnumerable<string> ChallengeTypes => [Constants.Dns01ChallengeType];
-        public override State State =>
+        public override State ExecutionState =>
             !Target.Parts.SelectMany(x => x.Identifiers).All(x => x.Type == IdentifierType.DnsName) ?
             State.DisabledState("DNS validation can only be used for DNS identifiers") :
             State.EnabledState();
@@ -35,7 +35,7 @@ namespace PKISharp.WACS.Plugins.Base.Capabilities
     {
         protected readonly Target Target = target;
         public override IEnumerable<string> ChallengeTypes => [Constants.TlsAlpn01ChallengeType];
-        public override State State =>
+        public override State ExecutionState =>
             Target.GetIdentifiers(false).Any(x => x.Value.StartsWith("*.")) ?
             State.DisabledState("TLS-ALPN validation cannot be used for wildcard identifiers (e.g. *.example.com)") :
             State.EnabledState();
@@ -45,6 +45,6 @@ namespace PKISharp.WACS.Plugins.Base.Capabilities
     {
         protected readonly Target Target = target;
         public override IEnumerable<string> ChallengeTypes => [Constants.Dns01ChallengeType, Constants.Http01ChallengeType, Constants.TlsAlpn01ChallengeType];
-        public override State State => State.EnabledState();
+        public override State ExecutionState => State.EnabledState();
     }
 }

--- a/src/main.lib/Plugins/Base/Interfaces/IPluginCapability.cs
+++ b/src/main.lib/Plugins/Base/Interfaces/IPluginCapability.cs
@@ -6,7 +6,17 @@ namespace PKISharp.WACS.Plugins.Interfaces
     public interface IPluginCapability
     {
         /// <summary>
-        /// Indicates whether the plugin is usable in the current context.
+        /// Indicates whether the plugin can be configured in the current context.
+        /// This is a more relaxed version of ExecutionState, enabling users to 
+        /// setup renewals that cannot be executed yet, but will be runnable by
+        /// the scheduled task (with more access rights) or when the pre execution 
+        /// scripts has run (e.g. to free port 80).
+        /// </summary>
+        /// <returns></returns>
+        State ConfigurationState { get; }
+
+        /// <summary>
+        /// Indicates whether the plugin can run in the current context.
         /// </summary>
         /// <returns></returns>
         State ExecutionState { get; }

--- a/src/main.lib/Plugins/Base/Interfaces/IPluginCapability.cs
+++ b/src/main.lib/Plugins/Base/Interfaces/IPluginCapability.cs
@@ -9,7 +9,7 @@ namespace PKISharp.WACS.Plugins.Interfaces
         /// Indicates whether the plugin is usable in the current context.
         /// </summary>
         /// <returns></returns>
-        State State { get; }
+        State ExecutionState { get; }
     }
 
     /// <summary>

--- a/src/main.lib/Plugins/Base/Resolvers/InteractiveResolver.cs
+++ b/src/main.lib/Plugins/Base/Resolvers/InteractiveResolver.cs
@@ -67,7 +67,7 @@ namespace PKISharp.WACS.Plugins.Resolvers
             // renewal (e.g. cannot validate wildcards using http-01)
             State combinedState(PluginFrontend<TCapability, TOptions> plugin)
             {
-                var baseState = plugin.Capability.State;
+                var baseState = plugin.Capability.ExecutionState;
                 if (baseState.Disabled)
                 {
                     return baseState;

--- a/src/main.lib/Plugins/Base/Resolvers/InteractiveResolver.cs
+++ b/src/main.lib/Plugins/Base/Resolvers/InteractiveResolver.cs
@@ -33,7 +33,8 @@ namespace PKISharp.WACS.Plugins.Resolvers
         private class PluginChoice<TCapability, TOptions>(
             Plugin meta,
             PluginFrontend<TCapability, TOptions> frontend,
-            State state,
+            State configurationState,
+            State executionState,
             string description,
             bool @default)
             where TCapability : IPluginCapability
@@ -41,7 +42,8 @@ namespace PKISharp.WACS.Plugins.Resolvers
         {
             public Plugin Meta { get; } = meta;
             public PluginFrontend<TCapability, TOptions> Frontend { get; } = frontend;
-            public State State { get; } = state;
+            public State ConfigurationState { get; } = configurationState;
+            public State ExecutionState { get; } = executionState;
             public string Description { get; } = description;
             public bool Default { get; set; } = @default;
         }
@@ -55,26 +57,27 @@ namespace PKISharp.WACS.Plugins.Resolvers
                 string? defaultParam1 = null,
                 string? defaultParam2 = null,
                 Func<PluginFrontend<TCapability, TOptions>, int>? sort = null, 
-                Func<TCapability, State>? state = null,
+                Func<TCapability, State>? configState = null,
                 Func<PluginFrontend<TCapability, TOptions>, string>? description = null,
-                bool allowAbort = true) 
+                bool allowAbort = true,
+                bool explain = true) 
                 where TCapability : IPluginCapability
                 where TOptions : PluginOptions, new()
         {
-            // Helper method to determine final usability state
+            // Helper method to determine final usability configurationState
             // combination of plugin being enabled (e.g. due to missing
             // administrator rights) and being a right fit for the current
             // renewal (e.g. cannot validate wildcards using http-01)
-            State combinedState(PluginFrontend<TCapability, TOptions> plugin)
+            State combinedConfigState(PluginFrontend<TCapability, TOptions> plugin)
             {
-                var baseState = plugin.Capability.ExecutionState;
+                var baseState = plugin.Capability.ConfigurationState;
                 if (baseState.Disabled)
                 {
                     return baseState;
                 }
-                else if (state != null)
+                else if (configState != null)
                 {
-                    return state(plugin.Capability);
+                    return configState(plugin.Capability);
                 }
                 return State.EnabledState();
             };
@@ -91,13 +94,14 @@ namespace PKISharp.WACS.Plugins.Resolvers
                 Select(plugin => new PluginChoice<TCapability, TOptions>(
                     plugin.Meta,
                     plugin,
-                    combinedState(plugin),
+                    combinedConfigState(plugin),
+                    plugin.Capability.ExecutionState,
                     description == null ? plugin.Meta.Description : description(plugin),
                     false)).
                 ToList();
            
             // Default out when there are no reasonable plugins to pick
-            if (options.Count == 0 || options.All(x => x.State.Disabled))
+            if (options.Count == 0 || options.All(x => x.ConfigurationState.Disabled))
             {
                 return null;
             }
@@ -129,12 +133,26 @@ namespace PKISharp.WACS.Plugins.Resolvers
                     showMenu = true;
                     continue;
                 }
-                if (defaultOption.State.Disabled)
+                if (defaultOption.ConfigurationState.Disabled)
                 {
-                    log.Warning("{n} plugin {x} not available: {m}",
-                        char.ToUpper(className[0]) + className[1..],
-                        defaultOption.Frontend.Meta.Name ?? backend.Name,
-                        defaultOption.State.Reason);
+                    if (explain)
+                    {
+                        log.Warning("{n} plugin {x} not available: {m}",
+                            char.ToUpper(className[0]) + className[1..],
+                            defaultOption.Frontend.Meta.Name ?? backend.Name,
+                            defaultOption.ConfigurationState.Reason);
+                    }
+                    showMenu = true;
+                }
+                else if (defaultOption.ExecutionState.Disabled)
+                {
+                    if (explain)
+                    {
+                        log.Warning("{n} plugin {x} might not work: {m}",
+                            char.ToUpper(className[0]) + className[1..],
+                            defaultOption.Frontend.Meta.Name ?? backend.Name,
+                            defaultOption.ExecutionState.Reason);
+                    }
                     showMenu = true;
                 }
                 else
@@ -150,7 +168,7 @@ namespace PKISharp.WACS.Plugins.Resolvers
             }
 
             // List plugins for generating new certificates
-            if (!string.IsNullOrEmpty(longDescription))
+            if (!string.IsNullOrEmpty(longDescription) && explain)
             {
                 inputService.CreateSpace();
                 inputService.Show(null, longDescription);
@@ -161,12 +179,38 @@ namespace PKISharp.WACS.Plugins.Resolvers
                        choice.Frontend,
                        description: choice.Description,
                        @default: choice.Default,
-                       state: choice.State);
+                       state: choice.ConfigurationState);
             }
 
-            return allowAbort
+            var result = allowAbort
                 ? await inputService.ChooseOptional(shortDescription, options, creator, "Abort")
                 : await inputService.ChooseRequired(shortDescription, options, creator);
+
+            if (result?.Capability.ExecutionState.Disabled == true) 
+            {
+                log.Warning("Chosen {n} plugin {x} might not work: {m}",
+                    char.ToUpper(className[0]) + className[1..],
+                    result.Meta.Name,
+                    result.Capability.ExecutionState.Reason);
+                var retry = await inputService.PromptYesNo("Switch to another one?", true);
+                if (retry)
+                {
+                    return await GetPlugin(
+                        step: step, 
+                        defaultBackends: defaultBackends,
+                        shortDescription: shortDescription, 
+                        longDescription: longDescription,
+                        defaultParam1: defaultParam1,
+                        defaultParam2: defaultParam2, 
+                        sort: sort,
+                        configState: configState,
+                        description: description, 
+                        allowAbort: allowAbort, 
+                        explain: false);
+                }
+            }
+
+            return result;
         }
 
         /// <summary>
@@ -323,7 +367,7 @@ namespace PKISharp.WACS.Plugins.Resolvers
             defaultParam1 = csv?.Count > installation.Count() ? csv[installation.Count()] : "";
             return await GetPlugin<IInstallationPluginCapability, InstallationPluginOptions>(
                 Steps.Installation,
-                state: x => x.CanInstall(stores.Select(x => x.Backend), installation.Select(x => x.Backend)),
+                configState: x => x.CanInstall(stores.Select(x => x.Backend), installation.Select(x => x.Backend)),
                 defaultParam1: defaultParam1,
                 defaultBackends: [defaultType, typeof(InstallationPlugins.Null)],
                 shortDescription: shortDescription,

--- a/src/main.lib/Plugins/Base/Resolvers/UnattendedResolver.cs
+++ b/src/main.lib/Plugins/Base/Resolvers/UnattendedResolver.cs
@@ -49,7 +49,7 @@ namespace PKISharp.WACS.Plugins.Resolvers
             // renewal (e.g. cannot validate wildcards using http-01)
             State combinedState(PluginFrontend<TCapability, TOptions> plugin)
             {
-                var baseState = plugin.Capability.State;
+                var baseState = plugin.Capability.ExecutionState;
                 if (baseState.Disabled)
                 {
                     return baseState;

--- a/src/main.lib/Plugins/Base/Resolvers/UnattendedResolver.cs
+++ b/src/main.lib/Plugins/Base/Resolvers/UnattendedResolver.cs
@@ -29,7 +29,8 @@ namespace PKISharp.WACS.Plugins.Resolvers
         private record PluginChoice<TCapability, TOptions>(
             Plugin Meta,
             PluginFrontend<TCapability, TOptions> Frontend,
-            State State)
+            State ConfigurationState,
+            State ExecutionState)
             where TOptions : PluginOptions, new()
             where TCapability : IPluginCapability;
 
@@ -39,7 +40,7 @@ namespace PKISharp.WACS.Plugins.Resolvers
                 Type defaultBackend,
                 string? defaultParam1 = null,
                 string? defaultParam2 = null,
-                Func<TCapability, State>? state = null)
+                Func<TCapability, State>? configState = null)
                 where TOptions : PluginOptions, new()
                 where TCapability : IPluginCapability
         {
@@ -47,16 +48,16 @@ namespace PKISharp.WACS.Plugins.Resolvers
             // combination of plugin being enabled (e.g. due to missing
             // administrator rights) and being a right fit for the current
             // renewal (e.g. cannot validate wildcards using http-01)
-            State combinedState(PluginFrontend<TCapability, TOptions> plugin)
+            State combinedConfigState(PluginFrontend<TCapability, TOptions> plugin)
             {
-                var baseState = plugin.Capability.ExecutionState;
+                var baseState = plugin.Capability.ConfigurationState;
                 if (baseState.Disabled)
                 {
                     return baseState;
                 }
-                else if (state != null)
+                else if (configState != null)
                 {
-                    return state(plugin.Capability);
+                    return configState(plugin.Capability);
                 }
                 return State.EnabledState();
             };
@@ -66,12 +67,12 @@ namespace PKISharp.WACS.Plugins.Resolvers
                 GetPlugins(step).
                 Select(x => autofacBuilder.PluginFrontend<TCapability, TOptions>(scope, x)).
                 Select(x => x.Resolve<PluginFrontend<TCapability, TOptions>>()).
-                Select(x => new PluginChoice<TCapability, TOptions>(x.Meta, x, combinedState(x))).
+                Select(x => new PluginChoice<TCapability, TOptions>(x.Meta, x, combinedConfigState(x), x.Capability.ExecutionState)).
                 ToList();
 
             // Default out when there are no reasonable plugins to pick
             var nullRet = Task.FromResult<PluginFrontend<TCapability, TOptions>?>(null);
-            if (options.Count == 0 || options.All(x => x.State.Disabled))
+            if (options.Count == 0 || options.All(x => x.ConfigurationState.Disabled))
             {
                 return nullRet;
             }
@@ -92,12 +93,15 @@ namespace PKISharp.WACS.Plugins.Resolvers
             }
 
             var defaultOption = options.OrderBy(x => x.Meta.Hidden).First(x => x.Meta.Backend == defaultBackend);
-            if (defaultOption.State.Disabled)
+            if (defaultOption.ConfigurationState.Disabled)
             {
-                log.Error("{n} plugin {x} not available: {m}. Choose another plugin using the {className} switch or change the default in settings.json", step, defaultOption.Frontend.Meta.Name ?? "Unknown", defaultOption.State.Reason?.TrimEnd('.'), $"--{className}");
+                log.Error("{n} plugin {x} not available: {m}. Choose another plugin using the {className} switch or change the default in settings.json", step, defaultOption.Frontend.Meta.Name ?? "Unknown", defaultOption.ConfigurationState.Reason?.TrimEnd('.'), $"--{className}");
                 return nullRet;
             }
-
+            if (defaultOption.ExecutionState.Disabled)
+            {
+                log.Warning("{n} plugin {x} might not work: {m}. If this leads to an error, choose another plugin using the {className} switch or change the default in settings.json", step, defaultOption.Frontend.Meta.Name ?? "Unknown", defaultOption.ExecutionState.Reason?.TrimEnd('.'), $"--{className}");
+            }
             return Task.FromResult<PluginFrontend<TCapability, TOptions>?>(defaultOption.Frontend);
         }
 
@@ -205,7 +209,7 @@ namespace PKISharp.WACS.Plugins.Resolvers
             }
             return await GetPlugin<IInstallationPluginCapability, InstallationPluginOptions>(
                 Steps.Installation,
-                state: x => x.CanInstall(stores.Select(x => x.Backend), installation.Select(x => x.Backend)),
+                configState: x => x.CanInstall(stores.Select(x => x.Backend), installation.Select(x => x.Backend)),
                 defaultParam1: defaultInstallation,
                 defaultBackend: typeof(InstallationPlugins.Null));
         }

--- a/src/main.lib/Plugins/InstallationPlugins/IIS/IISCapability.cs
+++ b/src/main.lib/Plugins/InstallationPlugins/IIS/IISCapability.cs
@@ -11,7 +11,7 @@ namespace PKISharp.WACS.Plugins.InstallationPlugins
 {
     internal class IISCapability(IUserRoleService userRole, IIISClient iisClient) : InstallationCapability
     {
-        public override State State
+        public override State ExecutionState
         {
             get
             {

--- a/src/main.lib/Plugins/OrderPlugins/Domain/DomainCapability.cs
+++ b/src/main.lib/Plugins/OrderPlugins/Domain/DomainCapability.cs
@@ -8,7 +8,7 @@ namespace PKISharp.WACS.Plugins.OrderPlugins
     {
         protected readonly Target Target = target;
 
-        public override State State => 
+        public override State ExecutionState => 
             Target.UserCsrBytes == null ? 
             State.EnabledState() : 
             State.DisabledState("Renewals sourced from a custom CSR cannot be split up");

--- a/src/main.lib/Plugins/OrderPlugins/Host/HostCapability.cs
+++ b/src/main.lib/Plugins/OrderPlugins/Host/HostCapability.cs
@@ -8,7 +8,7 @@ namespace PKISharp.WACS.Plugins.OrderPlugins
     {
         protected readonly Target Target = target;
 
-        public override State State =>
+        public override State ExecutionState =>
             Target.UserCsrBytes == null ?
             State.EnabledState() :
             State.DisabledState("Renewals sourced from a custom CSR cannot be split up");

--- a/src/main.lib/Plugins/OrderPlugins/Site/SiteCapability.cs
+++ b/src/main.lib/Plugins/OrderPlugins/Site/SiteCapability.cs
@@ -9,7 +9,7 @@ namespace PKISharp.WACS.Plugins.OrderPlugins
     {
         protected readonly Target Target = target;
 
-        public override State State
+        public override State ExecutionState
         {
             get
             {

--- a/src/main.lib/Plugins/StorePlugins/CertificateStore/CertificateStoreCapability.cs
+++ b/src/main.lib/Plugins/StorePlugins/CertificateStore/CertificateStoreCapability.cs
@@ -7,7 +7,7 @@ namespace PKISharp.WACS.Plugins.StorePlugins
 {
     internal class CertificateStoreCapability(IUserRoleService userRoleService) : DefaultCapability
     {
-        public override State State
+        public override State ExecutionState
         {
             get
             {

--- a/src/main.lib/Plugins/TargetPlugins/IIS/IISCapability.cs
+++ b/src/main.lib/Plugins/TargetPlugins/IIS/IISCapability.cs
@@ -8,7 +8,7 @@ namespace PKISharp.WACS.Plugins.TargetPlugins
 {
     internal class IISCapability(IUserRoleService userRole, IIISClient iisClient) : DefaultCapability
     {
-        public override State State
+        public override State ExecutionState
         {
             get
             {

--- a/src/main.lib/Plugins/ValidationPlugins/Http/SelfHosting/SelfHostingCapability.cs
+++ b/src/main.lib/Plugins/ValidationPlugins/Http/SelfHosting/SelfHostingCapability.cs
@@ -20,11 +20,11 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Http
             ArgumentsParser = args;
         } 
 
-        public override State State
+        public override State ExecutionState
         {
             get
             {
-                var baseState = base.State;
+                var baseState = base.ExecutionState;
                 if (baseState.Disabled)
                 {
                     return baseState;

--- a/src/main.lib/Plugins/ValidationPlugins/Tls/SelfHosting/SelfHostingCapability.cs
+++ b/src/main.lib/Plugins/ValidationPlugins/Tls/SelfHosting/SelfHostingCapability.cs
@@ -27,11 +27,11 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Tls
             ArgumentsParser = args;
         }
 
-        public override State State
+        public override State ExecutionState
         {
             get
             {
-                var baseState = base.State;
+                var baseState = base.ExecutionState;
                 if (baseState.Disabled)
                 {
                     return baseState;

--- a/src/main.lib/RenewalCreator.cs
+++ b/src/main.lib/RenewalCreator.cs
@@ -161,7 +161,7 @@ namespace PKISharp.WACS
                     {
                         var pluginFrontend = autofacBuilder.ValidationFrontend(targetPluginScope, options, identifier);
                         log.Debug("Global validation option {name} found for {identifier}", pluginFrontend.Meta.Name, identifier.Value);
-                        var state = pluginFrontend.Capability.State;
+                        var state = pluginFrontend.Capability.ExecutionState;
                         if (!state.Disabled)
                         {
                             mapping[identifier] = pluginFrontend;
@@ -197,7 +197,7 @@ namespace PKISharp.WACS
                     await input.WritePagedList(allIdentifiers.Select(identifier =>
                         Choice.Create(
                             identifier,
-                            $"{identifier.Value}: {mapping[identifier]?.Meta.Name ?? "-"}{(mapping[identifier]?.Capability.State.Disabled ?? false ? " (disabled)" : "")}")));
+                            $"{identifier.Value}: {mapping[identifier]?.Meta.Name ?? "-"}{(mapping[identifier]?.Capability.ExecutionState.Disabled ?? false ? " (disabled)" : "")}")));
                     input.CreateSpace();
                 }
 

--- a/src/main.lib/RenewalExecutor.cs
+++ b/src/main.lib/RenewalExecutor.cs
@@ -50,9 +50,9 @@ namespace PKISharp.WACS
             var client = await clientManager.GetClient(renewal.Account);
             using var es = scopeBuilder.Execution(_container, renewal, client, runLevel);
             var targetPlugin = es.Resolve<PluginBackend<ITargetPlugin, IPluginCapability, TargetPluginOptions>>();
-            if (targetPlugin.Capability.State.Disabled)
+            if (targetPlugin.Capability.ExecutionState.Disabled)
             {
-                return new RenewResult($"Source plugin {targetPlugin.Meta.Name} is disabled. {targetPlugin.Capability.State.Reason}");
+                return new RenewResult($"Source plugin {targetPlugin.Meta.Name} is disabled. {targetPlugin.Capability.ExecutionState.Reason}");
             }
             var target = await targetPlugin.Backend.Generate();
             if (target == null)

--- a/src/main.lib/RenewalValidator.cs
+++ b/src/main.lib/RenewalValidator.cs
@@ -227,7 +227,7 @@ namespace PKISharp.WACS
             }
             var identifier = Identifier.Parse(context.Authorization.Identifier);
             var pluginFrontend = scopeBuilder.ValidationFrontend(context.Order.OrderScope, options, identifier);
-            var state = pluginFrontend.Capability.State;
+            var state = pluginFrontend.Capability.ExecutionState;
             if (state.Disabled)
             {
                 log.Warning("Validation plugin {name} is not available. {disabledReason}", pluginFrontend.Meta.Name, state.Reason);

--- a/src/main.lib/Services/Http/RequestLogger.cs
+++ b/src/main.lib/Services/Http/RequestLogger.cs
@@ -41,7 +41,7 @@ namespace PKISharp.WACS.Services
             }
             else
             {
-                log.Warning("[HTTP] Request completed with status {s}", response.StatusCode);
+                log.Debug("[HTTP] Request completed with status {s}", response.StatusCode);
             }
             if (response.Content != null)
             {

--- a/src/plugin.store.userstore/UserStoreCapability.cs
+++ b/src/plugin.store.userstore/UserStoreCapability.cs
@@ -6,7 +6,7 @@ namespace PKISharp.WACS.Plugins.StorePlugins
 {
     internal class UserStoreCapability(AdminService adminService) : DefaultCapability
     {
-        public override State State =>
+        public override State ExecutionState =>
             adminService.IsSystem ?
             State.DisabledState("It doesn't make sense to use the user store plugin while running as SYSTEM.") :
             State.EnabledState();


### PR DESCRIPTION
Execution = false > fixable reasons (i.e. port unavailable, no permissions)
Configuration = false > completely illegal

Allow users to pick plugins where Configuration is true but Execution is false, presuming that something (plugin, pre-execution script) removes the blocking reason. 

Execution = false at execution time is still automatic fail though

fixes #164