### PR TITLE
Update NuGet references

### DIFF
--- a/src/main.lib/wacs.lib.csproj
+++ b/src/main.lib/wacs.lib.csproj
@@ -50,8 +50,10 @@
 		<PackageReference Include="Serilog.Sinks.EventLog" Version="4.0.0" />
 		<PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
 		<PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.8" />
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="System.Net.Http.WinHttpHandler" Version="9.0.8" />
 		<PackageReference Include="System.Security.Cryptography.ProtectedData" Version="9.0.8" />
+		<PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.2" />
 		<PackageReference Include="TaskScheduler" Version="2.12.2" />
 	</ItemGroup>
 


### PR DESCRIPTION
Take direct references to `System.Net.Http` and `System.Security.Cryptography.X509Certificates` instead of getting them indirectly via the mostly-unmaintained `Microsoft.Web.Administration` package, as to get the latest versions without known vulnerabilities.