### PR TITLE
self-hosting: fix server being started too late in test mode

### DIFF
--- a/src/main.lib/Plugins/ValidationPlugins/Http/SelfHosting/SelfHosting.cs
+++ b/src/main.lib/Plugins/ValidationPlugins/Http/SelfHosting/SelfHosting.cs
@@ -70,11 +70,12 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Http
         {
             // Add validation file
             _files.GetOrAdd($"/{Http01ChallengeValidationDetails.HttpPathPrefix}/{challenge.HttpResourceName}", challenge.HttpResourceValue);
+            StartListener();
             await TestChallenge(challenge);
             return true;
         }
 
-        public override Task Commit()
+        private void StartListener()
         {
             // Create listener if it doesn't exist yet
             lock (_listenerLock)
@@ -97,8 +98,9 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Http
                     }
                 }
             }
-            return Task.CompletedTask;
         }
+
+        public override Task Commit() => Task.CompletedTask;
 
         private static (HttpListener, int) CreateListener(bool? https, int? userPort)
         {


### PR DESCRIPTION
When running with `--test`, simple-acme will log the challenge URL and ask whether the user wants to open it in the default browser. But at this point, the listener hasn't even started yet, so the URL will not work.

Fix this by starting the listener in `PrepareChallenge()` instead of in `Commit()`.

Relevant log:

```
 [VERB] Handle authorization 1/1
 [INFO] [the.domain] Authorizing...
 [VERB] [the.domain] Initial authorization status: pending
 [VERB] [the.domain] Challenge types available: ["dns-persist-01", "http-01", "dns-01", "tls-alpn-01"]
 [VERB] [the.domain] Initial challenge status: pending
 [INFO] [the.domain] Authorizing using http-01 validation (Self-hosting)
 [INFO] Answer should now be browsable at http://the.domain/.well-known/acme-challenge/...

 [--test] Try in default browser? (y/n*) - yes
```