### PR TITLE
Add arguments for CSR scripts

### DIFF
--- a/src/main.lib/Plugins/TargetPlugins/Csr/Csr.cs
+++ b/src/main.lib/Plugins/TargetPlugins/Csr/Csr.cs
@@ -110,7 +110,7 @@ namespace PKISharp.WACS.Plugins.TargetPlugins
             // Get CSR from script
             if (!string.IsNullOrEmpty(options.CsrScript))
             {
-                var ret = await scriptClient.RunScript(options.CsrScript);
+                var ret = await scriptClient.RunScript(options.CsrScript, options.CsrScriptArguments);
                 if (!ret.Success)
                 {
                     throw new InvalidOperationException($"Script {options.CsrScript} unable to run");

--- a/src/main.lib/Plugins/TargetPlugins/Csr/CsrArguments.cs
+++ b/src/main.lib/Plugins/TargetPlugins/Csr/CsrArguments.cs
@@ -11,6 +11,9 @@ namespace PKISharp.WACS.Plugins.TargetPlugins
         [CommandLine(Description = "Specify the location of a script that will generate the CSR file on demand")]
         public string? CsrScript { get; set; }
 
+        [CommandLine(Name = "csrarguments", Description = "Arguments passed to the CSR script")]
+        public string? CsrScriptArguments { get; set; }
+
         [CommandLine(Description = "Specify the location of the private key corresponding to the CSR")]
         public string? PkFile { get; set; }
     }

--- a/src/main.lib/Plugins/TargetPlugins/Csr/CsrOptions.cs
+++ b/src/main.lib/Plugins/TargetPlugins/Csr/CsrOptions.cs
@@ -7,6 +7,7 @@ namespace PKISharp.WACS.Plugins.TargetPlugins
         public const string Trigger = "CSR";
         public string? CsrFile { get; set; }
         public string? CsrScript { get; set; }
+        public string? CsrScriptArguments { get; set; }
         public string? PkFile { get; set; }
     }
 }

--- a/src/main.lib/Plugins/TargetPlugins/Csr/CsrOptionsFactory.cs
+++ b/src/main.lib/Plugins/TargetPlugins/Csr/CsrOptionsFactory.cs
@@ -20,6 +20,11 @@ namespace PKISharp.WACS.Plugins.TargetPlugins
             GetString<CsrArguments>(x => x.CsrScript).
             Validate(x => Task.FromResult(x.ValidFile(log)), "invalid file");
 
+        private ArgumentResult<string?> CsrScriptArguments => arguments.
+            GetString<CsrArguments>(x => x.CsrScriptArguments).
+            WithLabel("Arguments").
+            WithDescription("Arguments passed to the CSR script.");
+
         private ArgumentResult<string?> PkFile => arguments.
             GetString<CsrArguments>(x => x.PkFile).
             Validate(x => Task.FromResult(x.ValidFile(log)), "invalid file");
@@ -44,7 +49,8 @@ namespace PKISharp.WACS.Plugins.TargetPlugins
             {
                 return new CsrOptions()
                 {
-                    CsrScript = await CsrScript.Interactive(inputService).Required().GetValue()
+                    CsrScript = await CsrScript.Interactive(inputService).Required().GetValue(),
+                    CsrScriptArguments = await CsrScriptArguments.Interactive(inputService).GetValue()
                 };
             }
         }
@@ -55,7 +61,8 @@ namespace PKISharp.WACS.Plugins.TargetPlugins
             {
                 PkFile = await PkFile.GetValue(),
                 CsrFile = await CsrFile.GetValue(),
-                CsrScript = await CsrScript.GetValue()
+                CsrScript = await CsrScript.GetValue(),
+                CsrScriptArguments = await CsrScriptArguments.GetValue()
             };
             if (string.IsNullOrWhiteSpace(ret.CsrFile) && string.IsNullOrEmpty(ret.CsrScript))
             {
@@ -68,6 +75,7 @@ namespace PKISharp.WACS.Plugins.TargetPlugins
         {
             yield return (CsrFile.Meta, options.CsrFile);
             yield return (CsrScript.Meta, options.CsrScript);
+            yield return (CsrScriptArguments.Meta, options.CsrScriptArguments);
             yield return (PkFile.Meta, options.PkFile);
         }
     }

--- a/src/main.test/Tests/TargetPluginTests/CsrScriptArgumentTests.cs
+++ b/src/main.test/Tests/TargetPluginTests/CsrScriptArgumentTests.cs
@@ -1,0 +1,104 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PKISharp.WACS.Configuration;
+using PKISharp.WACS.DomainObjects;
+using PKISharp.WACS.Plugins.TargetPlugins;
+using PKISharp.WACS.Services;
+using PKISharp.WACS.UnitTests.Mock;
+using PKISharp.WACS.UnitTests.Mock.Services;
+using System.IO;
+using System.Linq;
+
+namespace PKISharp.WACS.UnitTests.Tests.TargetPluginTests
+{
+    [TestClass]
+    public class CsrScriptArgumentTests
+    {
+        /// <summary>
+        /// Generated using https://certificatetools.com/
+        /// </summary>
+        private readonly string Csr = @"-----BEGIN CERTIFICATE REQUEST-----
+MIIDSzCCAjMCAQAwWzEZMBcGA1UEAwwQd3d3Lndpbi1hY21lLmNvbTELMAkGA1UE
+BhMCSFUxHzAdBgNVBAgMFkJvcnNvZC1BYmHDumotWmVtcGzDqW4xEDAOBgNVBAcM
+B01pc2tvbGMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDhDFr/lZBY
+aew4dayZTDd4J7a0eMkUUQsAI3oNRwp4opaxTLretfJVGjdmEdHa0goKeLUFCUAJ
+9aOe4ik0wY79MMaNPt8MPOnZDTLBc9bVqdDZI62GzbyJxgFZ1/QJWN3e0ZOd8TC9
+P+UU+3KEJvZPaEs4FcI8MqCdO/Xx31BFuRH63odXPDYF6YMMegdp8ZkLsm3BR8Zl
+9A0Rd/XrOJpO8tt19hvr0O11DbSDZ2FSAZzoJ+GOw8hUtKlju/dj0iOJxYNj1aTx
+qBLVNnT02tIhHAaEbiHtwfOybGuPDdRt/NB/D6vYjGEVSVwr/mvd95aI+h8SZ/Ra
+EgWNyULO0dhnAgMBAAGggaowgacGCSqGSIb3DQEJDjGBmTCBljAOBgNVHQ8BAf8E
+BAMCBaAwIAYDVR0lAQH/BBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMGIGA1UdEQRb
+MFmHBAEBAQGHBAECAwSHEGhNERECIjMzRERVVQAGAHeCDHdpbi1hY21lLmNvbYIQ
+d3d3Lndpbi1hY21lLmNvbYEZd2luLmFjbWUuc2ltcGxlQGdtYWlsLmNvbTANBgkq
+hkiG9w0BAQsFAAOCAQEAxZ5EiV6M17v2pW1wJJXbI/1KKMhY05gyPq+pHNal5qRE
+rArwt9y/WISNmX+PUsMBEqUqZtNFdP/oMwcqLjfV4stL6mFCmHhy/X2X6VR3G6SC
+qfXgA/fJq+14DqnnC1p4Ww/65xAE8br8QHxVZ5G5k9RQ6+Tfs22sVJLjt7UdN7yu
+cz+2LLTM86nhWmffpNR+C+C4wmB7Sq9zN3ty5Qn1e7yVKJIn3duQYgMoIEEGdhP9
+pT4M4qdY0+SDgKptoHhBEAeeCbBMYewBH/5l1qMd7KWROiNxA5Gt00TSX3xkz/bY
+ZkoLUgEWU5OcCkq5AIpmloeaCTC/vKrlS5M3BvjEmQ==
+-----END CERTIFICATE REQUEST-----";
+
+        private CsrOptions? Options(string commandLine)
+        {
+            var log = new Mock.Services.LogService(false);
+            var plugins = new PluginService(log, new MockAssemblyService(log));
+            var optionsParser = new ArgumentsParser(log, new MockAssemblyService(log), commandLine.Split(' '));
+            var input = new Mock.Services.InputService([]);
+            var secretService = new SecretServiceManager(MockContainer.TestScope(), input, plugins, log);
+            var argsInput = new ArgumentsInputService(log, optionsParser, input, secretService);
+            var factory = new CsrOptionsFactory(log, argsInput);
+            return factory.Default().Result;
+        }
+
+        [TestMethod]
+        public void OptionsAcceptScriptArguments()
+        {
+            var tempFile = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllText(tempFile, "");
+                var options = Options($"--csrscript {tempFile} --csrarguments bean-labs");
+                Assert.IsNotNull(options);
+                Assert.AreEqual(tempFile, options.CsrScript);
+                Assert.AreEqual("bean-labs", options.CsrScriptArguments);
+            }
+            finally
+            {
+                File.Delete(tempFile);
+            }
+        }
+
+        [TestMethod]
+        public void ScriptReceivesArguments()
+        {
+            var tempFile = Path.GetTempFileName() + ".sh";
+            try
+            {
+                File.WriteAllText(tempFile, Script(Csr));
+                var csrOptions = new CsrOptions() { CsrScript = tempFile, CsrScriptArguments = "bean-labs" };
+                var log = new Mock.Services.LogService(false);
+                var csrPlugin = new Csr(log, csrOptions, new Clients.ScriptClient(log, new MockSettingsService()));
+                var target = csrPlugin.Generate().Result;
+                Assert.IsNotNull(target);
+                Assert.AreEqual(1, target.Parts.Count);
+                Assert.AreEqual(3, target.Parts.First().Identifiers.OfType<IpIdentifier>().Count());
+                Assert.AreEqual(2, target.Parts.First().Identifiers.OfType<DnsIdentifier>().Count());
+                Assert.AreEqual(1, target.Parts.First().Identifiers.OfType<EmailIdentifier>().Count());
+                Assert.IsTrue(target.Parts.First().Identifiers.OfType<IpIdentifier>().Any(x => x.Value == "1.1.1.1"));
+                Assert.IsTrue(target.Parts.First().Identifiers.OfType<DnsIdentifier>().Any(x => x.Value == "www.win-acme.com"));
+                Assert.IsTrue(target.Parts.First().Identifiers.OfType<EmailIdentifier>().Any(x => x.Value == "win.acme.simple@gmail.com"));
+            }
+            finally
+            {
+                File.Delete(tempFile);
+            }
+        }
+
+        private static string Script(string csr) =>
+            $@"if [ ""$1"" != ""bean-labs"" ]; then
+  exit 1
+fi
+cat <<'CSR'
+{csr}
+CSR";
+    }
+}


### PR DESCRIPTION
Fixes #613.

## Summary
- add `--csrarguments` for dynamic CSR scripts
- persist the value in CSR options and show it in renewal descriptions
- pass the configured arguments into `ScriptClient.RunScript` when the CSR is generated
- add regression coverage for CLI mapping and script execution with arguments

## Tests
- `dotnet test src/main.test/wacs.test.csproj --filter 'FullyQualifiedName~CsrScriptArgumentTests|FullyQualifiedName=PKISharp.WACS.UnitTests.Tests.TargetPluginTests.CsrTests.Regular'`