### PR TITLE
Add configurable SMTP local domain

### DIFF
--- a/src/main.lib/Clients/EmailClient.cs
+++ b/src/main.lib/Clients/EmailClient.cs
@@ -23,6 +23,7 @@ namespace PKISharp.WACS.Clients
 #pragma warning enable
 
         private readonly string _server;
+        private readonly string? _localDomain;
         private readonly int _port;
         private readonly string _user;
         private readonly string _password;
@@ -43,6 +44,7 @@ namespace PKISharp.WACS.Clients
             _log = log;
             _settings = settings;
             _server = _settings.Notification.Email.SmtpServer;
+            _localDomain = _settings.Notification.Email.SmtpLocalDomain;
             _port = _settings.Notification.Email.SmtpPort;
             _user = _settings.Notification.Email.SmtpUser;
             _password = _settings.Notification.Email.SmtpPassword;
@@ -96,6 +98,7 @@ namespace PKISharp.WACS.Clients
             using var client = new SmtpClient(logger);
             try
             {
+                client.LocalDomain = _localDomain;
                 var options = SecureSocketOptions.None;
                 if (_secure)
                 {

--- a/src/main.lib/Configuration/Settings/Types/Notification/EmailSettings.cs
+++ b/src/main.lib/Configuration/Settings/Types/Notification/EmailSettings.cs
@@ -66,6 +66,11 @@ namespace PKISharp.WACS.Configuration.Settings.Types.Notification
         string? SmtpServer { get; }
 
         /// <summary>
+        /// Domain name used in the SMTP HELO or EHLO command.
+        /// </summary>
+        string? SmtpLocalDomain { get; }
+
+        /// <summary>
         /// User name for the SMTP server, in case 
         /// of authenticated SMTP.
         /// </summary>
@@ -83,6 +88,7 @@ namespace PKISharp.WACS.Configuration.Settings.Types.Notification
         public bool SmtpSecure => Get(x => x.SmtpSecure) ?? true;
         public int SmtpSecureMode => Get(x => x.SmtpSecureMode) ?? 1;
         public string? SmtpServer => Get(x => x.SmtpServer);
+        public string? SmtpLocalDomain => Get(x => x.SmtpLocalDomain);
         public string? SmtpUser => Get(x => x.SmtpUser);
     }
 
@@ -92,6 +98,12 @@ namespace PKISharp.WACS.Configuration.Settings.Types.Notification
             SubType = "host",
             Description = "SMTP server to use for sending email notifications. Required to receive renewal failure notifications.")]
         public string? SmtpServer { get; set; }
+
+        [SettingsValue(
+            SubType = "host",
+            Description = "Domain name used in the SMTP HELO or EHLO command.",
+            NullBehaviour = "the local IP address will be used")]
+        public string? SmtpLocalDomain { get; set; }
 
         [SettingsValue(
             Default = "25",

--- a/src/main.test/Tests/SettingsTests/SettingsTests.cs
+++ b/src/main.test/Tests/SettingsTests/SettingsTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PKISharp.WACS.Configuration.Settings;
 using PKISharp.WACS.Configuration.Settings.Types;
+using PKISharp.WACS.Configuration.Settings.Types.Notification;
 using System;
 
 namespace PKISharp.WACS.UnitTests.Tests.SettingsTests
@@ -144,6 +145,36 @@ namespace PKISharp.WACS.UnitTests.Tests.SettingsTests
             };
             var x = new InheritSettings(renewallSettings, localSettings, globalSettings); 
             Assert.IsNull(x.Acme.PublicSuffixListUri);
+        }
+    }
+
+    [TestClass]
+    public class EmailSettingsTests
+    {
+        [TestMethod]
+        public void SmtpLocalDomainDefaultsToNull()
+        {
+            var settings = new InheritSettings(new Settings());
+
+            Assert.IsNull(settings.Notification.Email!.SmtpLocalDomain);
+        }
+
+        [TestMethod]
+        public void SmtpLocalDomainCanBeConfigured()
+        {
+            var globalSettings = new Settings
+            {
+                Notification = new NotificationSettings
+                {
+                    Email = new EmailSettings
+                    {
+                        SmtpLocalDomain = "mail.example.com"
+                    }
+                }
+            };
+            var settings = new InheritSettings(globalSettings);
+
+            Assert.AreEqual("mail.example.com", settings.Notification.Email!.SmtpLocalDomain);
         }
     }
 }

--- a/src/main/settings.json
+++ b/src/main/settings.json
@@ -56,6 +56,7 @@
     "ComputerName": null,
     "Email": {
       "SmtpServer": null,
+      "SmtpLocalDomain": null,
       "SmtpPort": 25,
       "SmtpUser": null,
       "SmtpPassword": null,

--- a/src/main/settings.linux.json
+++ b/src/main/settings.linux.json
@@ -53,6 +53,7 @@
     "ComputerName": null,
     "Email": {
       "SmtpServer": null,
+      "SmtpLocalDomain": null,
       "SmtpPort": 25,
       "SmtpUser": null,
       "SmtpPassword": null,


### PR DESCRIPTION
## Summary

Add an optional `SmtpLocalDomain` setting for email notifications and pass it to MailKit before connecting to the SMTP server.

## Motivation

Some SMTP servers require a specific fully qualified domain name in the `HELO` or `EHLO` command. The email client previously always relied on MailKit's default local address, with no way to override it.

Closes #655

## What changed

- added `SmtpLocalDomain` to the inherited email settings and both default settings files
- applied the configured value to `SmtpClient.LocalDomain`
- added coverage for the default and configured setting values

## Validation

- `dotnet build src/main.test/wacs.test.csproj --configuration Release --no-restore`
- `dotnet test src/main.test/wacs.test.csproj --configuration Debug --no-restore --filter FullyQualifiedName~EmailSettingsTests`

The focused tests pass (2/2). A full local run passed 397 tests; seven existing PowerShell Core script tests could not start because PowerShell 7 is not installed at the path expected by the test environment.
