### PR TITLE
Add DNS validation plugin for IP-Projects.de

### DIFF
--- a/src/plugin.validation.dns.ipprojects/IPProjects.cs
+++ b/src/plugin.validation.dns.ipprojects/IPProjects.cs
@@ -10,46 +10,13 @@ using System.Threading.Tasks;
 namespace PKISharp.WACS.Plugins.ValidationPlugins;
 
 /// <summary>
-/// This is a reference implementation of a DNS validation plugin.
-/// Designed as an example for developers to create their own.
-///
-/// This class is the heart of the plugin, it implements the functions
-/// required to create and delete DNS records for challengeDomain validation.
-///
-/// This IPlugin.Plugin1 decorator registers the plugin with the WACS
-/// framework, Its generic parameters are:
-///
-/// - ReferenceArguments: The arguments class that defines the command line options for the plugin
-/// - ReferenceOptions: The options class that holds the configuration for the plugin as stored on disk
-/// - ReferenceOptionsFactory: The factory class that creates instances of ReferenceOptions during renewal setup
-/// - ReferenceJson: JSON serialization helper for ReferenceOptions, required for saving and loading options
-/// - DnsValidationCapability: The capability that indicates this plugin can perform DNS validation
-///
-/// Other parameters:
-/// - GUID:                A unique identifier for the plugin:
-///                        TODO: you should generate your own GUID
-/// - Trigger:             A human-readable name for the plugin, shown in the WACS UI and used
-///                        as command line option (e.g. --validation reference)
-///                        TODO: make this unique to your plugin
-/// - Description:         A short description of what the plugin does, shown in the WACS UI
-///                        TODO: make this unique to your plugin
-/// - External:            Indicates that this plugin is an external plugin, meaning it is not
-///                        part of the core WACS distribution
-/// - Provider:            Use only if the DNS service has a strong seperate brand from its
-///                        parent company, e.g. "Route53" has provider "Amazon AWS".
-///                        TODO: fill this only when applicable
+/// DNS validation plugin for ip-projects.de
 /// </summary>
-/// <param name="options">The options as stored in the JSON for the renewal</param>
-/// <param name="dnsClient">Required for the base class to do DNS lookups</param>
-/// <param name="log">Allow you to write to the logger</param>
-/// <param name="settings">Effective settings.json settings for the renewal</param>
-/// <param name="proxy">Used by base class to generate HttpClient with proper proxy settings</param>
-/// <param name="ssm">Can be used to access secrets from the secret manager</param>
 [IPlugin.Plugin1<IPProjectsOptions, IPProjectsOptionsFactory,
                  DnsValidationCapability, IPProjectsJson, IPProjectsArguments>
                 ("6370923c-7840-4e8c-b003-a3b514312e5a",
                  "IPProjects",
-                 "Create verification records at IP-Projects.de",
+                 "Create verification records at ip-projects.de",
                  External = true,
                  Provider = null)]
 internal class IPProjects(IPProjectsOptions options,

--- a/src/plugin.validation.dns.ipprojects/IPProjects.cs
+++ b/src/plugin.validation.dns.ipprojects/IPProjects.cs
@@ -94,7 +94,7 @@ internal class IPProjects(IPProjectsOptions options,
             recordName = recordName == "@" ? string.Empty : recordName;
 
             IPProjectsClient client = await GetClient();
-            await client.AddRecord(domain, recordName, record.Value);
+            await client.DeleteRecord(domain, recordName, record.Value);
         }
         catch (Exception ex)
         {

--- a/src/plugin.validation.dns.ipprojects/IPProjects.cs
+++ b/src/plugin.validation.dns.ipprojects/IPProjects.cs
@@ -1,0 +1,104 @@
+using PKISharp.WACS.Clients.DNS;
+using PKISharp.WACS.Plugins.Base.Capabilities;
+using PKISharp.WACS.Plugins.Interfaces;
+using PKISharp.WACS.Plugins.ValidationPlugins.Dns;
+using PKISharp.WACS.Services;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins;
+
+/// <summary>
+/// This is a reference implementation of a DNS validation plugin.
+/// Designed as an example for developers to create their own.
+///
+/// This class is the heart of the plugin, it implements the functions
+/// required to create and delete DNS records for challengeDomain validation.
+///
+/// This IPlugin.Plugin1 decorator registers the plugin with the WACS
+/// framework, Its generic parameters are:
+///
+/// - ReferenceArguments: The arguments class that defines the command line options for the plugin
+/// - ReferenceOptions: The options class that holds the configuration for the plugin as stored on disk
+/// - ReferenceOptionsFactory: The factory class that creates instances of ReferenceOptions during renewal setup
+/// - ReferenceJson: JSON serialization helper for ReferenceOptions, required for saving and loading options
+/// - DnsValidationCapability: The capability that indicates this plugin can perform DNS validation
+///
+/// Other parameters:
+/// - GUID:                A unique identifier for the plugin:
+///                        TODO: you should generate your own GUID
+/// - Trigger:             A human-readable name for the plugin, shown in the WACS UI and used
+///                        as command line option (e.g. --validation reference)
+///                        TODO: make this unique to your plugin
+/// - Description:         A short description of what the plugin does, shown in the WACS UI
+///                        TODO: make this unique to your plugin
+/// - External:            Indicates that this plugin is an external plugin, meaning it is not
+///                        part of the core WACS distribution
+/// - Provider:            Use only if the DNS service has a strong seperate brand from its
+///                        parent company, e.g. "Route53" has provider "Amazon AWS".
+///                        TODO: fill this only when applicable
+/// </summary>
+/// <param name="options">The options as stored in the JSON for the renewal</param>
+/// <param name="dnsClient">Required for the base class to do DNS lookups</param>
+/// <param name="log">Allow you to write to the logger</param>
+/// <param name="settings">Effective settings.json settings for the renewal</param>
+/// <param name="proxy">Used by base class to generate HttpClient with proper proxy settings</param>
+/// <param name="ssm">Can be used to access secrets from the secret manager</param>
+[IPlugin.Plugin1<IPProjectsOptions, IPProjectsOptionsFactory,
+                 DnsValidationCapability, IPProjectsJson, IPProjectsArguments>
+                ("6370923c-7840-4e8c-b003-a3b514312e5a",
+                 "IPProjects",
+                 "Create verification records at IP-Projects.de",
+                 External = true,
+                 Provider = null)]
+internal class IPProjects(IPProjectsOptions options,
+                          LookupClientProvider dnsClient,
+                          ILogService log,
+                          ISettings settings,
+                          IProxyService proxy,
+                          SecretServiceManager ssm,
+                          DomainParseService domainParser)
+    : DnsValidation<IPProjects, IPProjectsClient>(dnsClient, log, settings, proxy)
+{
+    protected override async Task<IPProjectsClient> CreateClient(HttpClient httpClient)
+    {
+        string apiKey = await ssm.EvaluateSecret(options.ApiKey) ?? "";
+        return new IPProjectsClient(httpClient, apiKey);
+    }
+
+    public override async Task<bool> CreateRecord(DnsValidationRecord record)
+    {
+        try
+        {
+            string domain = domainParser.GetRegisterableDomain(record.Authority.Domain);
+            string recordName = RelativeRecordName(domain, record.Authority.Domain);
+            recordName = recordName == "@" ? string.Empty : recordName;
+
+            IPProjectsClient client = await GetClient();
+            return await client.AddRecord(domain, recordName, record.Value);
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Unhandled exception when attempting to create record");
+            return false;
+        }
+    }
+
+    public override async Task DeleteRecord(DnsValidationRecord record)
+    {
+        try
+        {
+            string domain = domainParser.GetRegisterableDomain(record.Authority.Domain);
+            string recordName = RelativeRecordName(domain, record.Authority.Domain);
+            recordName = recordName == "@" ? string.Empty : recordName;
+
+            IPProjectsClient client = await GetClient();
+            await client.AddRecord(domain, recordName, record.Value);
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Unhandled exception when attempting to delete record");
+        }
+    }
+}

--- a/src/plugin.validation.dns.ipprojects/IPProjectsArguments.cs
+++ b/src/plugin.validation.dns.ipprojects/IPProjectsArguments.cs
@@ -1,0 +1,13 @@
+using PKISharp.WACS.Configuration;
+using PKISharp.WACS.Configuration.Arguments;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins;
+
+/// <summary>
+/// Command line arguments for unattended mode.
+/// </summary>
+public sealed class IPProjectsArguments : BaseArguments
+{
+    [CommandLine(Description = "API Access Key from Dashboard", Secret = true)]
+    public string? ApiKey { get; set; }
+}

--- a/src/plugin.validation.dns.ipprojects/IPProjectsClient.cs
+++ b/src/plugin.validation.dns.ipprojects/IPProjectsClient.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins;
+
+public class IPProjectsClient
+{
+    private readonly HttpClient httpClient;
+
+    private const string baseUri = "https://api.ip-projects.de/v1/dns/acme/";
+
+    public IPProjectsClient(HttpClient httpClient, string clientSecret)
+    {
+        httpClient.DefaultRequestHeaders.Add("X-API-Key", clientSecret);
+        httpClient.BaseAddress = new Uri(baseUri);
+        this.httpClient = httpClient;
+    }
+
+    internal async Task<bool> AddRecord(string domain, string key, string value)
+    {
+        return await PostAction("add", domain, key, value);
+    }
+
+    internal async Task<bool> DeleteRecord(string domain, string key, string value)
+    {
+        return await PostAction("remove", domain, key, value);
+    }
+
+    private async Task<bool> PostAction(string action, string domain, string key, string value)
+    {
+        using HttpResponseMessage response = await httpClient.PostAsJsonAsync(action, new { domain, key, value });
+        return response.IsSuccessStatusCode;
+    }
+}

--- a/src/plugin.validation.dns.ipprojects/IPProjectsOptions.cs
+++ b/src/plugin.validation.dns.ipprojects/IPProjectsOptions.cs
@@ -1,0 +1,18 @@
+using PKISharp.WACS.Plugins.Base.Options;
+using PKISharp.WACS.Services.Serialization;
+using System.Text.Json.Serialization;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins;
+
+[JsonSerializable(typeof(IPProjectsOptions))]
+internal partial class IPProjectsJson : JsonSerializerContext
+{
+    public IPProjectsJson(WacsJsonPluginsOptionsFactory optionsFactory) : base(optionsFactory.Options)
+    {
+    }
+}
+
+internal class IPProjectsOptions : ValidationPluginOptions
+{
+    public ProtectedString? ApiKey { get; set; }
+}

--- a/src/plugin.validation.dns.ipprojects/IPProjectsOptionsFactory.cs
+++ b/src/plugin.validation.dns.ipprojects/IPProjectsOptionsFactory.cs
@@ -24,8 +24,6 @@ internal class IPProjectsOptionsFactory(ArgumentsInputService arguments) : Plugi
 
     /// <summary>
     /// This is called when the user is setting up a new renewal interactively
-    /// You have access to the input service, which allows you to ask questions
-    /// and prompt feedback to the screen.
     /// </summary>
     /// <param name="input"></param>
     /// <param name="runLevel"></param>

--- a/src/plugin.validation.dns.ipprojects/IPProjectsOptionsFactory.cs
+++ b/src/plugin.validation.dns.ipprojects/IPProjectsOptionsFactory.cs
@@ -1,0 +1,64 @@
+using PKISharp.WACS.Configuration;
+using PKISharp.WACS.Plugins.Base.Factories;
+using PKISharp.WACS.Services;
+using PKISharp.WACS.Services.Serialization;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns;
+
+/// <summary>
+/// This class is responsible for creating an options object,
+/// either interactively or from the command line
+/// </summary>
+internal class IPProjectsOptionsFactory(ArgumentsInputService arguments) : PluginOptionsFactory<IPProjectsOptions>
+{
+    /// <summary>
+    /// Getter for the ApiKey argument, which is a protected
+    /// string so the user can enter vault:// references and is also
+    /// offered to store the value into the secret manager.
+    /// </summary>
+    private ArgumentResult<ProtectedString?> ApiKey => arguments.
+        GetProtectedString<IPProjectsArguments>(a => a.ApiKey).
+        Required();
+
+    /// <summary>
+    /// This is called when the user is setting up a new renewal interactively
+    /// You have access to the input service, which allows you to ask questions
+    /// and prompt feedback to the screen.
+    /// </summary>
+    /// <param name="input"></param>
+    /// <param name="runLevel"></param>
+    /// <returns></returns>
+    public override async Task<IPProjectsOptions?> Aquire(IInputService input, RunLevel runLevel)
+    {
+        return new IPProjectsOptions()
+        {
+            ApiKey = await ApiKey.Interactive(input).GetValue(),
+        };
+    }
+
+    /// <summary>
+    /// This is called when the user is setting up a new renewal from the
+    /// command line. No user input is possible.
+    /// </summary>
+    /// <returns></returns>
+    public override async Task<IPProjectsOptions?> Default()
+    {
+        return new IPProjectsOptions()
+        {
+            ApiKey = await ApiKey.GetValue(),
+        };
+    }
+
+    /// <summary>
+    /// This method is used to describe the current configuration when
+    /// the user goes to Manage Renewals => Show Details.
+    /// </summary>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    public override IEnumerable<(CommandLineAttribute, object?)> Describe(IPProjectsOptions options)
+    {
+        yield return (ApiKey.Meta, options.ApiKey);
+    }
+}

--- a/src/plugin.validation.dns.ipprojects/wacs.validation.dns.ipprojects.csproj
+++ b/src/plugin.validation.dns.ipprojects/wacs.validation.dns.ipprojects.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>PKISharp.WACS.Plugins.ValidationPlugins.IPProjects</AssemblyName>
+    <RootNamespace>PKISharp.WACS.Plugins.ValidationPlugins</RootNamespace>
+    <Version>2.1.0.0</Version>
+    <AssemblyVersion>2.1.0.0</AssemblyVersion>
+    <FileVersion>2.1.0.0</FileVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\main.lib\wacs.lib.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/wacs.slnx
+++ b/src/wacs.slnx
@@ -91,6 +91,10 @@
       <BuildType Solution="DebugTrimmed|*" Project="Debug" />
       <BuildType Solution="ReleaseTrimmed|*" Project="Release" />
     </Project>
+    <Project Path="plugin.validation.dns.ipprojects/wacs.validation.dns.ipprojects.csproj">
+      <BuildType Solution="DebugTrimmed|*" Project="Debug" />
+      <BuildType Solution="ReleaseTrimmed|*" Project="Release" />
+    </Project>
     <Project Path="plugin.validation.dns.linode/wacs.validation.dns.linode.csproj">
       <BuildType Solution="DebugTrimmed|*" Project="Debug" />
       <BuildType Solution="ReleaseTrimmed|*" Project="Release" />


### PR DESCRIPTION
Added the DNS validation plugin for DNS records at [IP-Projects](https://www.ip-projects.de), allowing for automatic validation and renewals.