### PR TITLE
Add DNS validation plugin for Level27

### DIFF
--- a/src/plugin.validation.dns.level27/Level27.cs
+++ b/src/plugin.validation.dns.level27/Level27.cs
@@ -1,0 +1,103 @@
+using PKISharp.WACS.Clients.DNS;
+using PKISharp.WACS.Plugins.Base.Capabilities;
+using PKISharp.WACS.Plugins.Interfaces;
+using PKISharp.WACS.Plugins.ValidationPlugins.Dns;
+using PKISharp.WACS.Services;
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins
+{
+    [IPlugin.Plugin1<
+        Level27Options, Level27OptionsFactory,
+        DnsValidationCapability, Level27Json, Level27Arguments>
+        ("55891a42-ca55-4085-b107-b6a0c4f6f30b",
+        "Level27", "Create verification records in Level27 DNS",
+        External = true)]
+    internal class Level27Validation(
+        Level27Options options,
+        LookupClientProvider dnsClient,
+        ILogService log,
+        ISettings settings,
+        IProxyService proxy,
+        SecretServiceManager ssm,
+        DomainParseService domainParser) : DnsValidation<Level27Validation, Level27Client>(dnsClient, log, settings, proxy)
+    {
+        protected override async Task<Level27Client> CreateClient(HttpClient httpClient)
+        {
+            var apiKey = await ssm.EvaluateSecret(options.ApiKey) ?? "";
+            return new Level27Client(httpClient, apiKey, options.ApiBaseUrl);
+        }
+
+        /// <summary>
+        /// Create a DNS record required by the ACME server
+        /// </summary>
+        /// <param name="record"></param>
+        /// <returns></returns>
+        public override async Task<bool> CreateRecord(DnsValidationRecord record)
+        {
+            try
+            {
+                var zone = await GetHostZone(record.Authority.Domain);
+                if (zone == null)
+                {
+                    _log.Error("Unable to find zone for {challengeDomain}", record.Authority.Domain);
+                    return false;
+                }
+                var host = RelativeRecordName(zone.Name, record.Authority.Domain);
+                var client = await GetClient();
+                _log.Debug("Creating TXT record for {host} with value {value}", host, record.Value);
+                await client.CreateTxtRecord(zone, host, record.Value);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex, "Unhandled exception when attempting to create record");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Delete the TXT record after validation has been completed
+        /// </summary>
+        /// <param name="record"></param>
+        /// <returns></returns>
+        public override async Task DeleteRecord(DnsValidationRecord record)
+        {
+            try
+            {
+                var zone = await GetHostZone(record.Authority.Domain);
+                if (zone == null)
+                {
+                    _log.Warning("Unable to find zone for {challengeDomain}", record.Authority.Domain);
+                    return;
+                }
+                var client = await GetClient();
+                var host = RelativeRecordName(zone.Name, record.Authority.Domain);
+                _log.Debug("Deleting TXT record for {host} with value {value}", host, record.Value);
+                await client.DeleteTxtRecord(zone, host, record.Value);
+            }
+            catch (Exception ex)
+            {
+                _log.Warning(ex, $"Unable to delete record");
+            }
+        }
+
+        /// <summary>
+        /// Select the best matching zone for the given challenge domain. A single
+        /// query returns the registered domain as well as any delegated
+        /// subdomains, so the most specific match is chosen.
+        /// </summary>
+        /// <param name="challengeDomain"></param>
+        /// <returns></returns>
+        private async Task<Level27Zone?> GetHostZone(string challengeDomain)
+        {
+            var client = await GetClient();
+            var registeredDomain = domainParser.GetRegisterableDomain(challengeDomain);
+            var zones = await client.GetZones(registeredDomain);
+            return FindBestMatch(zones.ToDictionary(x => x.Name), challengeDomain);
+        }
+    }
+}

--- a/src/plugin.validation.dns.level27/Level27Arguments.cs
+++ b/src/plugin.validation.dns.level27/Level27Arguments.cs
@@ -1,0 +1,14 @@
+using PKISharp.WACS.Configuration;
+using PKISharp.WACS.Configuration.Arguments;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins
+{
+    public sealed class Level27Arguments : BaseArguments
+    {
+        [CommandLine(Description = "API key for your Level27 account. Get one from the Level27 control panel (https://app.level27.eu/account/profile/security).", Secret = true)]
+        public string? ApiKey { get; set; }
+
+        [CommandLine(Description = "Optional. Level27 API base URL. Defaults to https://api.level27.eu/v1.")]
+        public string? ApiBaseUrl { get; set; }
+    }
+}

--- a/src/plugin.validation.dns.level27/Level27Client/Level27Client.cs
+++ b/src/plugin.validation.dns.level27/Level27Client/Level27Client.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins
+{
+    /// <summary>
+    /// Minimal client for the Level27 DNS API.
+    /// See https://api.level27.eu/v1 and the official Go client
+    /// (https://github.com/level27/l27-go) for the API shapes used here.
+    /// </summary>
+    class Level27Client
+    {
+        /// <summary>
+        /// Default Level27 API endpoint.
+        /// </summary>
+        internal const string DefaultEndpoint = "https://api.level27.eu/v1";
+
+        private readonly HttpClient _httpClient;
+
+        /// <summary>
+        /// Create a client for the Level27 API. Authentication is done by
+        /// sending the API key in the Authorization header, as implemented in
+        /// the official acme.sh integration written by Level27.
+        /// </summary>
+        /// <param name="httpClient"></param>
+        /// <param name="apiKey"></param>
+        /// <param name="apiBaseUrl"></param>
+        public Level27Client(HttpClient httpClient, string apiKey, string? apiBaseUrl)
+        {
+            var endpoint = string.IsNullOrWhiteSpace(apiBaseUrl) ? DefaultEndpoint : apiBaseUrl.TrimEnd('/');
+            httpClient.BaseAddress = new Uri(endpoint + "/");
+            httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", apiKey);
+            _httpClient = httpClient;
+        }
+
+        /// <summary>
+        /// Look up the zones that match the given domain name. The Level27 API
+        /// filter is a substring search, so this can return the registered
+        /// domain as well as any delegated subdomains.
+        /// </summary>
+        /// <param name="domain"></param>
+        /// <returns></returns>
+        internal async Task<IEnumerable<Level27Zone>> GetZones(string domain)
+        {
+            var response = await GetRequest<Level27DomainList>($"domains?filter={WebUtility.UrlEncode(domain)}", "retrieve zone list");
+            return response.Domains.Select(d => new Level27Zone { Id = d.Id, Name = d.Fullname });
+        }
+
+        /// <summary>
+        /// Create a TXT record in the specified zone. Existing records are left
+        /// untouched because the Level27 API adds a new record for each POST.
+        /// </summary>
+        /// <param name="zone"></param>
+        /// <param name="host"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        internal async Task CreateTxtRecord(Level27Zone zone, string host, string value)
+        {
+            var body = new { name = host, type = "TXT", content = value };
+            using var response = await _httpClient.PostAsJsonAsync($"domains/{zone.Id}/records", body);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new Exception($"Unable to create TXT record: {response.ReasonPhrase}");
+            }
+        }
+
+        /// <summary>
+        /// Delete the TXT record with the exact host and value from the zone,
+        /// so that any pre-existing TXT records the user may have are preserved.
+        /// </summary>
+        /// <param name="zone"></param>
+        /// <param name="host"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        internal async Task DeleteTxtRecord(Level27Zone zone, string host, string value)
+        {
+            var records = await GetRequest<Level27RecordList>($"domains/{zone.Id}/records?type=TXT", "retrieve TXT records");
+            var record = records.Records.FirstOrDefault(r =>
+                string.Equals(r.Type, "TXT", StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(r.Name, host, StringComparison.OrdinalIgnoreCase) &&
+                MatchesValue(r.Content, value));
+            if (record == null)
+            {
+                throw new Exception("Unable to find exact record for deletion");
+            }
+            using var response = await _httpClient.DeleteAsync($"domains/{zone.Id}/records/{record.Id}");
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new Exception($"Unable to delete TXT record: {response.ReasonPhrase}");
+            }
+        }
+
+        /// <summary>
+        /// The Level27 API may store TXT content with or without surrounding
+        /// quotes, so accept both representations when matching.
+        /// </summary>
+        /// <param name="content"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        private static bool MatchesValue(string content, string value) =>
+            string.Equals(content, value, StringComparison.Ordinal) ||
+            string.Equals(content, $"\"{value}\"", StringComparison.Ordinal);
+
+        /// <summary>
+        /// Common handler for GET requests to the Level27 API. Note that the
+        /// custom HttpClient already handles request and response logging, so we
+        /// only catch errors and throw exceptions if needed.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="url"></param>
+        /// <param name="log"></param>
+        /// <returns></returns>
+        /// <exception cref="Exception"></exception>
+        private async Task<T> GetRequest<T>(string url, string log)
+        {
+            using var response = await _httpClient.GetAsync(url);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new Exception($"Unable to {log}: {response.ReasonPhrase}");
+            }
+            await using var stream = await response.Content.ReadAsStreamAsync();
+            var result = await JsonSerializer.DeserializeAsync<T>(stream);
+            return result ?? throw new Exception($"Unable to {log}");
+        }
+    }
+}

--- a/src/plugin.validation.dns.level27/Level27Client/Level27Zone.cs
+++ b/src/plugin.validation.dns.level27/Level27Client/Level27Zone.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins
+{
+    /// <summary>
+    /// Wrapper for the response of GET domains?filter={name}
+    /// </summary>
+    class Level27DomainList
+    {
+        [JsonPropertyName("domains")]
+        public List<Level27Domain> Domains { get; set; } = [];
+    }
+
+    /// <summary>
+    /// A single domain (zone) as returned by the Level27 API
+    /// </summary>
+    class Level27Domain
+    {
+        [JsonPropertyName("id")]
+        public long Id { get; set; }
+
+        [JsonPropertyName("fullname")]
+        public string Fullname { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Internal representation of a Level27 DNS zone that is used
+    /// throughout the plugin.
+    /// </summary>
+    class Level27Zone
+    {
+        public long Id { get; set; }
+
+        /// <summary>
+        /// Fully qualified name of the zone, e.g. "example.com"
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Wrapper for the response of GET domains/{id}/records
+    /// </summary>
+    class Level27RecordList
+    {
+        [JsonPropertyName("records")]
+        public List<Level27Record> Records { get; set; } = [];
+    }
+
+    /// <summary>
+    /// Wrapper for the response of POST domains/{id}/records
+    /// </summary>
+    class Level27RecordResponse
+    {
+        [JsonPropertyName("record")]
+        public Level27Record? Record { get; set; }
+    }
+
+    /// <summary>
+    /// A single DNS record as returned by the Level27 API
+    /// </summary>
+    class Level27Record
+    {
+        [JsonPropertyName("id")]
+        public long Id { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = string.Empty;
+
+        [JsonPropertyName("content")]
+        public string Content { get; set; } = string.Empty;
+    }
+}

--- a/src/plugin.validation.dns.level27/Level27Options.cs
+++ b/src/plugin.validation.dns.level27/Level27Options.cs
@@ -1,0 +1,23 @@
+using PKISharp.WACS.Plugins.Base.Options;
+using PKISharp.WACS.Services.Serialization;
+using System.Text.Json.Serialization;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins
+{
+    [JsonSerializable(typeof(Level27Options))]
+    internal partial class Level27Json : JsonSerializerContext
+    {
+        public Level27Json(WacsJsonPluginsOptionsFactory optionsFactory) : base(optionsFactory.Options) { }
+    }
+
+    internal class Level27Options : ValidationPluginOptions
+    {
+        public ProtectedString? ApiKey { get; set; }
+
+        /// <summary>
+        /// Optional override for the Level27 API base URL. When null the
+        /// default (https://api.level27.eu/v1) is used.
+        /// </summary>
+        public string? ApiBaseUrl { get; set; }
+    }
+}

--- a/src/plugin.validation.dns.level27/Level27OptionsFactory.cs
+++ b/src/plugin.validation.dns.level27/Level27OptionsFactory.cs
@@ -1,0 +1,43 @@
+using PKISharp.WACS.Configuration;
+using PKISharp.WACS.Plugins.Base.Factories;
+using PKISharp.WACS.Services;
+using PKISharp.WACS.Services.Serialization;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
+{
+    internal class Level27OptionsFactory(ArgumentsInputService arguments) : PluginOptionsFactory<Level27Options>
+    {
+        private ArgumentResult<ProtectedString?> ApiKey => arguments.
+            GetProtectedString<Level27Arguments>(a => a.ApiKey).
+            Required();
+
+        private ArgumentResult<string?> ApiBaseUrl => arguments.
+            GetString<Level27Arguments>(a => a.ApiBaseUrl);
+
+        public override async Task<Level27Options?> Aquire(IInputService input, RunLevel runLevel)
+        {
+            return new Level27Options()
+            {
+                ApiKey = await ApiKey.Interactive(input).GetValue(),
+                ApiBaseUrl = await ApiBaseUrl.GetValue(),
+            };
+        }
+
+        public override async Task<Level27Options?> Default()
+        {
+            return new Level27Options()
+            {
+                ApiKey = await ApiKey.GetValue(),
+                ApiBaseUrl = await ApiBaseUrl.GetValue(),
+            };
+        }
+
+        public override IEnumerable<(CommandLineAttribute, object?)> Describe(Level27Options options)
+        {
+            yield return (ApiKey.Meta, options.ApiKey);
+            yield return (ApiBaseUrl.Meta, options.ApiBaseUrl);
+        }
+    }
+}

--- a/src/plugin.validation.dns.level27/README.md
+++ b/src/plugin.validation.dns.level27/README.md
@@ -1,0 +1,47 @@
+# Level27 DNS validation plugin (dns-01)
+
+This plugin enables DNS-01 validation using the [Level27](https://www.level27.be/)
+DNS API. Level27 is a Belgian managed hosting provider.
+
+It creates and removes the `_acme-challenge` TXT records automatically using the
+Level27 REST API:
+
+-   `GET    domains?filter={domain}` — find the zone
+-   `POST   domains/{id}/records` — create a TXT record
+-   `GET    domains/{id}/records?type=TXT` — list TXT records
+-   `DELETE domains/{id}/records/{recordId}` — remove a TXT record
+
+Authentication is done by sending the API key in the `Authorization` HTTP
+header.
+
+## Requirements
+
+-   A Level27 API key. Create one in the Level27 control panel under
+    [My Profile → Security](https://app.level27.eu/account/profile/security).
+
+## Usage
+
+### Interactive
+
+Run `wacs` and choose DNS validation. Select **Level27** and provide:
+
+-   API key
+-   (optional) API base URL (advanced)
+
+### Unattended (CLI)
+
+Example:
+
+    wacs --target manual --host example.com --validation level27 --apikey "YOUR_API_KEY" --store pemfiles --pemfilespath /tmp/certs
+
+Notes:
+
+-   `--validation level27` selects this DNS provider.
+-   `--apikey` is stored as a secret and can also reference the secret manager
+    (e.g. `vault://...`).
+-   Wildcard certificates (`*.example.com`) are supported.
+
+## Configuration options
+
+-   **API key** (required, sent as the `Authorization` header)
+-   **API base URL** (optional, default: `https://api.level27.eu/v1`)

--- a/src/plugin.validation.dns.level27/wacs.validation.dns.level27.csproj
+++ b/src/plugin.validation.dns.level27/wacs.validation.dns.level27.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>PKISharp.WACS.Plugins.ValidationPlugins.Level27</AssemblyName>
+    <RootNamespace>PKISharp.WACS.Plugins.ValidationPlugins</RootNamespace>
+    <Version>2.1.0.0</Version>
+    <AssemblyVersion>2.1.0.0</AssemblyVersion>
+    <FileVersion>2.1.0.0</FileVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\main.lib\wacs.lib.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/wacs.slnx
+++ b/src/wacs.slnx
@@ -95,6 +95,10 @@
       <BuildType Solution="DebugTrimmed|*" Project="Debug" />
       <BuildType Solution="ReleaseTrimmed|*" Project="Release" />
     </Project>
+    <Project Path="plugin.validation.dns.level27/wacs.validation.dns.level27.csproj">
+      <BuildType Solution="DebugTrimmed|*" Project="Debug" />
+      <BuildType Solution="ReleaseTrimmed|*" Project="Release" />
+    </Project>
     <Project Path="plugin.validation.dns.linode/wacs.validation.dns.linode.csproj">
       <BuildType Solution="DebugTrimmed|*" Project="Debug" />
       <BuildType Solution="ReleaseTrimmed|*" Project="Release" />


### PR DESCRIPTION
Adds a `dns-01` validation plugin for the Level27 (level27.be) managed hosting DNS API.

## What it does
- Lookups the zone ID based on the domainname
- Creates the `_acme-challenge` TXT record 
- Removes it after validation
- Authenticates with the API key in the `Authorization` header

## Files
- New plugin project `src/plugin.validation.dns.level27` (client, options, factory, arguments, README)
- Registered in `src/wacs.slnx` (Debug/Release build mappings, matching other DNS plugins)

## Testing
- Full solution builds cleanly (0 warnings, 0 errors)
- `JsonTests.PluginTests` pass (plugin auto-discovered and options (de)serialize)
- Verified end-to-end: TXT record created via the Level27 API, challenge validated, TXT record cleaned up, and certificate issued/exported.