### PR TITLE
Fix scheduled task working directory with winget alias

### DIFF
--- a/src/main.lib/Services/AutoRenew/CronJobService.cs
+++ b/src/main.lib/Services/AutoRenew/CronJobService.cs
@@ -16,7 +16,7 @@ namespace PKISharp.WACS.Services.AutoRenew
         private string CronScriptTemplate => $@"
 #!/bin/sh
 # Automatically created by {VersionService.DefaultClientName}: https://github.com/simple-acme/simple-acme/
-cd {Path.GetDirectoryName(VersionService.ExePath)}
+cd {VersionService.ExeDirectory}
 ./wacs --{nameof(MainArguments.Renew).ToLowerInvariant()} --{nameof(MainArguments.BaseUri).ToLowerInvariant()} ""{settings.BaseUri}""";
 
         /// <summary>

--- a/src/main.lib/Services/AutoRenew/TaskSchedulerService.cs
+++ b/src/main.lib/Services/AutoRenew/TaskSchedulerService.cs
@@ -18,7 +18,7 @@ namespace PKISharp.WACS.Services
         ILogService log) : IAutoRenewService
     {
         private string TaskName => $"{settings.Client.ClientName.CleanPath()} renew ({settings.BaseUri.CleanUri()})";
-        private static string WorkingDirectory => Path.GetDirectoryName(VersionService.ExePath) ?? "";
+        private static string WorkingDirectory => VersionService.ExeDirectory;
         private static string ExecutingFile => Path.GetFileName(VersionService.ExePath);
 
         private Task? ExistingTask

--- a/src/main.lib/Services/VersionService.cs
+++ b/src/main.lib/Services/VersionService.cs
@@ -84,6 +84,14 @@ namespace PKISharp.WACS.Services
         internal static bool DotNetTool => LaunchInfo.Value?.Name == "wacs.dll" && !Debug;
         internal static string SettingsPath => DotNetTool ? Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), DefaultClientName) : BasePath.Value;
         internal static string ExePath => ExeFileInfo.Value?.FullName ?? string.Empty;
+
+        /// <summary>
+        /// Directory that the program should run from, i.e. the location of the
+        /// real executable and its resources, with symlinks and junctions resolved.
+        /// Note that this may differ from the directory of <see cref="ExePath"/>,
+        /// which points to the shortcut that the scheduled task should launch.
+        /// </summary>
+        internal static string ExeDirectory => BasePath.Value.TrimEnd(Path.DirectorySeparatorChar);
         internal static string ResourcePath => BasePath.Value;
         internal static string Bitness => Environment.Is64BitProcess ? "64-bit" : "32-bit";
         internal static bool Pluggable =>


### PR DESCRIPTION
Hi @WouterTinus,

If you prefer to avoid AI-assisted contributions feel free to reject this PR.
This change makes the automatic-renewal scheduled task use the real installation path (resolving symlinks) for the working directory instead of the launch alias. That ensures renewals run from the actual simple-acme install directory.