### PR TITLE
Add DNSMint DNS validation plugin

### DIFF
--- a/src/plugin.validation.dns.dnsmint/DnsMint.cs
+++ b/src/plugin.validation.dns.dnsmint/DnsMint.cs
@@ -1,0 +1,65 @@
+﻿using PKISharp.WACS.Clients.DNS;
+using PKISharp.WACS.Plugins.Base.Capabilities;
+using PKISharp.WACS.Plugins.Interfaces;
+using PKISharp.WACS.Plugins.ValidationPlugins.Dns;
+using PKISharp.WACS.Services;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins
+{
+    [IPlugin.Plugin1<
+        DnsMintOptions, DnsMintOptionsFactory,
+        DnsValidationCapability, DnsMintJson, DnsMintArguments>
+        ("87b5008b-62f2-4dd6-9fd7-30b46e4ddfd5",
+        "DnsMint", "Create verification records in DNSMint",
+        External = true)]
+    internal class DnsMintValidation(
+        DnsMintOptions options,
+        LookupClientProvider dnsClient,
+        ILogService log,
+        ISettings settings,
+        IProxyService proxy,
+        SecretServiceManager ssm) : DnsValidation<DnsMintValidation, DnsMintClient>(dnsClient, log, settings, proxy)
+    {
+        protected override async Task<DnsMintClient> CreateClient(HttpClient httpClient)
+        {
+            var apiKey = await ssm.EvaluateSecret(options.ApiKey) ?? "";
+            return new DnsMintClient(httpClient, apiKey);
+        }
+
+        /// <summary>
+        /// The record name goes to the API unchanged. DNSMint works out which
+        /// hostname it belongs to, so there is no zone lookup and no
+        /// RelativeRecordName.
+        /// </summary>
+        public override async Task<bool> CreateRecord(DnsValidationRecord record)
+        {
+            try
+            {
+                var client = await GetClient();
+                await client.CreateTxtRecord(record.Authority.Domain, record.Value);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex, "Unhandled exception when attempting to create record");
+                return false;
+            }
+        }
+
+        public override async Task DeleteRecord(DnsValidationRecord record)
+        {
+            try
+            {
+                var client = await GetClient();
+                await client.DeleteTxtRecord(record.Authority.Domain, record.Value);
+            }
+            catch (Exception ex)
+            {
+                _log.Warning(ex, "Unable to delete record");
+            }
+        }
+    }
+}

--- a/src/plugin.validation.dns.dnsmint/DnsMintArguments.cs
+++ b/src/plugin.validation.dns.dnsmint/DnsMintArguments.cs
@@ -1,0 +1,15 @@
+﻿using PKISharp.WACS.Configuration;
+using PKISharp.WACS.Configuration.Arguments;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins
+{
+    /// <summary>
+    /// Command line arguments for unattended mode. An API key is the whole
+    /// credential, and it is marked Secret so it stays out of the logs.
+    /// </summary>
+    public sealed class DnsMintArguments : BaseArguments
+    {
+        [CommandLine(Description = "DNSMint API key, carrying the dns01:write scope.", Secret = true)]
+        public string? ApiKey { get; set; }
+    }
+}

--- a/src/plugin.validation.dns.dnsmint/DnsMintClient/DnsMintClient.cs
+++ b/src/plugin.validation.dns.dnsmint/DnsMintClient/DnsMintClient.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins
+{
+    /// <summary>
+    /// Minimal client for the DNSMint DNS-01 API, which serves the shape
+    /// lego's httpreq provider posts: the finished record name and value.
+    /// See https://dnsmint.com/api-reference.
+    ///
+    /// There is no zone to look up and no record id to keep. The hostname is
+    /// derived from the record name server-side, and cleanup names the value
+    /// to remove, so records the user already had are left alone.
+    /// </summary>
+    class DnsMintClient
+    {
+        internal const string Endpoint = "https://dnsmint.com/api/httpreq/";
+
+        private readonly HttpClient _httpClient;
+
+        public DnsMintClient(HttpClient httpClient, string apiKey)
+        {
+            httpClient.BaseAddress = new Uri(Endpoint);
+            httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", $"Bearer {apiKey}");
+            _httpClient = httpClient;
+        }
+
+        internal Task CreateTxtRecord(string recordName, string value) =>
+            Post("present", recordName, value, "create TXT record");
+
+        internal Task DeleteTxtRecord(string recordName, string value) =>
+            Post("cleanup", recordName, value, "delete TXT record");
+
+        private async Task Post(string action, string recordName, string value, string log)
+        {
+            var body = new { fqdn = recordName.EndsWith('.') ? recordName : recordName + ".", value };
+            using var response = await _httpClient.PostAsJsonAsync(action, body);
+            if (!response.IsSuccessStatusCode)
+            {
+                var detail = await response.Content.ReadAsStringAsync();
+                throw new Exception($"Unable to {log}: {response.ReasonPhrase}. {detail}");
+            }
+        }
+    }
+}

--- a/src/plugin.validation.dns.dnsmint/DnsMintOptions.cs
+++ b/src/plugin.validation.dns.dnsmint/DnsMintOptions.cs
@@ -1,0 +1,23 @@
+﻿using PKISharp.WACS.Plugins.Base.Options;
+using PKISharp.WACS.Services.Serialization;
+using System.Text.Json.Serialization;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins
+{
+    /// <summary>
+    /// Generated code for (de)serializing DnsMintOptions.
+    /// </summary>
+    [JsonSerializable(typeof(DnsMintOptions))]
+    internal partial class DnsMintJson : JsonSerializerContext
+    {
+        public DnsMintJson(WacsJsonPluginsOptionsFactory optionsFactory) : base(optionsFactory.Options) { }
+    }
+
+    internal class DnsMintOptions : ValidationPluginOptions
+    {
+        /// <summary>
+        /// Encrypted in renewal.json.
+        /// </summary>
+        public ProtectedString? ApiKey { get; set; }
+    }
+}

--- a/src/plugin.validation.dns.dnsmint/DnsMintOptionsFactory.cs
+++ b/src/plugin.validation.dns.dnsmint/DnsMintOptionsFactory.cs
@@ -1,0 +1,37 @@
+﻿using PKISharp.WACS.Configuration;
+using PKISharp.WACS.Plugins.Base.Factories;
+using PKISharp.WACS.Services;
+using PKISharp.WACS.Services.Serialization;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
+{
+    internal class DnsMintOptionsFactory(ArgumentsInputService arguments) : PluginOptionsFactory<DnsMintOptions>
+    {
+        private ArgumentResult<ProtectedString?> ApiKey => arguments.
+            GetProtectedString<DnsMintArguments>(a => a.ApiKey).
+            Required();
+
+        public override async Task<DnsMintOptions?> Aquire(IInputService input, RunLevel runLevel)
+        {
+            return new DnsMintOptions()
+            {
+                ApiKey = await ApiKey.Interactive(input).GetValue()
+            };
+        }
+
+        public override async Task<DnsMintOptions?> Default()
+        {
+            return new DnsMintOptions()
+            {
+                ApiKey = await ApiKey.GetValue()
+            };
+        }
+
+        public override IEnumerable<(CommandLineAttribute, object?)> Describe(DnsMintOptions options)
+        {
+            yield return (ApiKey.Meta, options.ApiKey);
+        }
+    }
+}

--- a/src/plugin.validation.dns.dnsmint/README.md
+++ b/src/plugin.validation.dns.dnsmint/README.md
@@ -1,0 +1,43 @@
+# DNSMint DNS validation plugin (dns-01)
+
+This plugin enables DNS-01 validation using [DNSMint](https://dnsmint.com), a
+DNS host that gives each account a dedicated domain and mints hostnames on it
+over an API.
+
+It publishes and withdraws the `_acme-challenge` TXT record through two calls:
+
+-   `POST /api/httpreq/present` — publish the challenge value
+-   `POST /api/httpreq/cleanup` — withdraw it
+
+Both take `{"fqdn", "value"}`. Authentication is an API key in the
+`Authorization` header as a bearer token.
+
+There is no zone lookup and no record id. DNSMint derives the hostname from the
+record name, and cleanup names the value to remove, so any TXT records the user
+already had are left alone.
+
+## Requirements
+
+-   A DNSMint API key carrying the `dns01:write` scope. Create one under API
+    keys in the dashboard. A key can be narrowed to a single hostname.
+
+## Usage
+
+### Interactive
+
+Run `wacs`, choose DNS validation, select **DnsMint** and provide the API key.
+
+### Unattended (CLI)
+
+    wacs --target manual --host example.com,*.example.com --validation dnsmint --apikey "YOUR_API_KEY" --store pemfiles --pemfilespath /tmp/certs
+
+Notes:
+
+-   `--apikey` is stored as a secret and can reference the secret manager
+    (e.g. `vault://...`).
+-   Wildcard certificates are supported. A hostname and its wildcard validate
+    against the same challenge name, so one key covers both.
+
+## Configuration options
+
+-   **API key** (required, sent as a bearer token)

--- a/src/plugin.validation.dns.dnsmint/wacs.validation.dns.dnsmint.csproj
+++ b/src/plugin.validation.dns.dnsmint/wacs.validation.dns.dnsmint.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>PKISharp.WACS.Plugins.ValidationPlugins.DnsMint</AssemblyName>
+    <RootNamespace>PKISharp.WACS.Plugins.ValidationPlugins</RootNamespace>
+    <Version>2.1.0.0</Version>
+    <AssemblyVersion>2.1.0.0</AssemblyVersion>
+    <FileVersion>2.1.0.0</FileVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\main.lib\wacs.lib.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/wacs.slnx
+++ b/src/wacs.slnx
@@ -63,6 +63,10 @@
       <BuildType Solution="DebugTrimmed|*" Project="Debug" />
       <BuildType Solution="ReleaseTrimmed|*" Project="Release" />
     </Project>
+    <Project Path="plugin.validation.dns.dnsmint/wacs.validation.dns.dnsmint.csproj">
+      <BuildType Solution="DebugTrimmed|*" Project="Debug" />
+      <BuildType Solution="ReleaseTrimmed|*" Project="Release" />
+    </Project>
     <Project Path="plugin.validation.dns.domeneshop/wacs.validation.dns.domeneshop.csproj">
       <BuildType Solution="DebugTrimmed|*" Project="Debug" />
       <BuildType Solution="ReleaseTrimmed|*" Project="Release" />


### PR DESCRIPTION
A DNS validation plugin for [DNSMint](https://dnsmint.com), a DNS host that gives each account a dedicated domain and mints hostnames on it over an API.

```
wacs.exe --target manual --host example.dnsmint-108bd2.top,*.example.dnsmint-108bd2.top ^
  --validation dnsmint --apikey <key>
```

Built from `plugin.validation.dns.reference`. No `DomainParseService` or `RelativeRecordName`: the API derives the hostname from the record name, so `CreateRecord` passes `record.Authority.Domain` through unchanged. Publishing and withdrawing are one POST each, and cleanup names the value to remove, so pre-existing TXT records are untouched.

Windows Server 2022, .NET 10.0.401, `dotnet build src/wacs.slnx -c Release`: `0 Error(s)`, and the 3 warnings are the existing `MSTEST0065` ones in `main.test`. The `Unit tests` workflow on `windows-latest` is green on this branch, 406 of 406.

Unattended against Let's Encrypt staging, for a name and its wildcard:

```
[*.winacme.dnsmint-108bd2.top] Authorizing using dns-01 validation (DnsMint)
[*.winacme.dnsmint-108bd2.top] Record Nv3sOeM5qWAQ9UCQTE3v7WYZOHFcSKTscMdoIPt9BEA successfully created
[*.winacme.dnsmint-108bd2.top] [167.233.249.72] No TXT records found
[*.winacme.dnsmint-108bd2.top] Preliminary validation failed on all nameservers
[*.winacme.dnsmint-108bd2.top] Will retry in 30 seconds (retry 1/10)...
[*.winacme.dnsmint-108bd2.top] Preliminary validation succeeded
[*.winacme.dnsmint-108bd2.top] Authorization result: valid
[*.winacme.dnsmint-108bd2.top] Record Nv3sOeM5qWAQ9UCQTE3v7WYZOHFcSKTscMdoIPt9BEA deleted
[winacme.dnsmint-108bd2.top] Authorizing using dns-01 validation (DnsMint)
[winacme.dnsmint-108bd2.top] Record mqtPEYoUINY_zY9U1XNtMeP_WIfrma-e9KBaGtqpQkk successfully created
[winacme.dnsmint-108bd2.top] Authorization result: valid
[winacme.dnsmint-108bd2.top] Record mqtPEYoUINY_zY9U1XNtMeP_WIfrma-e9KBaGtqpQkk deleted
Certificate [Manual] winacme.dnsmint-108bd2.top created
```

The certificate covers both names. The first pre-validation miss is propagation on our side.
